### PR TITLE
fix(tvos): Selected Chips were getting cut off and selected theme colour was not clear

### DIFF
--- a/app/SourcesTV/ChipButtonStyle.swift
+++ b/app/SourcesTV/ChipButtonStyle.swift
@@ -10,15 +10,18 @@ struct ChipButtonStyle: ButtonStyle {
     var selected: Bool = false
     var accent: Color = Theme.Palette.accent
     var accentText: Color = Theme.Palette.accent
+    private let focusMargin: CGFloat = 5
 
     func makeBody(configuration: Configuration) -> some View {
-        Chip(selected: selected, accent: accent, accentText: accentText, configuration: configuration)
+        Chip(selected: selected, accent: accent, accentText: accentText,
+             focusMargin: focusMargin, configuration: configuration)
     }
 
     private struct Chip: View {
         let selected: Bool
         let accent: Color
         let accentText: Color
+        let focusMargin: CGFloat
         let configuration: ButtonStyleConfiguration
         @Environment(\.isFocused) private var focused: Bool
         @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -32,7 +35,9 @@ struct ChipButtonStyle: ButtonStyle {
                 .background(fill, in: Capsule(style: .continuous))
                 .overlay(Capsule(style: .continuous).strokeBorder(accent, lineWidth: focused ? 3 : 0))
                 .scaleEffect(configuration.isPressed ? 0.97 : (focused && !reduceMotion ? 1.06 : 1))
-                .shadow(color: accent.opacity(focused ? 0.4 : 0), radius: 18, y: 8)
+                .padding(focusMargin)
+                .contentShape(Capsule(style: .continuous))
+                .focusEffectDisabled()
                 .animation(reduceMotion ? nil : Theme.Motion.focus, value: focused)
         }
 

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -173,13 +173,12 @@ struct SettingsView: View {
                 HStack(spacing: Theme.Space.md) {
                     ForEach(ThemeManager.accents) { opt in
                         Button { theme.accentID = opt.id } label: {
-                            Circle().fill(opt.base).frame(width: 58, height: 58)
-                                .overlay(Circle().strokeBorder(Theme.Palette.textPrimary,
-                                                               lineWidth: theme.accentID == opt.id ? 5 : 0))
+                            AccentCircle(color: opt.base, selected: theme.accentID == opt.id)
                         }
                         .buttonStyle(CardFocusStyle())
                     }
                 }
+                .padding(.horizontal, Theme.Space.sm)
                 .padding(.vertical, Theme.Space.xs)
             }
             choiceRow("Background", [("warm", "Warm"), ("oled", "OLED Black")],
@@ -268,5 +267,26 @@ struct SettingsView: View {
             Text(value).foregroundStyle(Theme.Palette.textSecondary)
         }
         .font(Theme.Typography.body)
+    }
+}
+
+private struct AccentCircle: View {
+    let color: Color
+    let selected: Bool
+    @Environment(\.isFocused) private var focused
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 58, height: 58)
+            .overlay(Circle().strokeBorder(ringColor, lineWidth: ringWidth))
+    }
+
+    private var ringColor: Color {
+        focused ? Theme.Palette.accentBright : Theme.Palette.textPrimary
+    }
+
+    private var ringWidth: CGFloat {
+        focused || selected ? 5 : 0
     }
 }


### PR DESCRIPTION
|Before | After|
| -------- | ------- |
| <img width="658" height="624" alt="Screenshot 2026-06-10 at 16 56 38" src="https://github.com/user-attachments/assets/b9c26721-4394-49b0-a02b-53b795c4dff5" /> | <img width="568" height="612" alt="Screenshot 2026-06-10 at 17 16 41" src="https://github.com/user-attachments/assets/93d9d938-e1ff-4338-9918-3a340d65867a" /> |


### Adding an effect around selected colour to make it more obvious where your cursor is

<img width="347" height="259" alt="Screenshot 2026-06-10 at 17 26 08" src="https://github.com/user-attachments/assets/d2b3fbc8-21be-4fc1-80d9-eef7b901ad68" />