### PR TITLE
feat: Add sign in button to logged out pages

### DIFF
--- a/app/SourcesTV/SharedUI.swift
+++ b/app/SourcesTV/SharedUI.swift
@@ -501,6 +501,10 @@ struct CoreEmptyState: View {
     let systemImage: String
     let title: String
     let message: String
+    var showsSignInButton = false
+    @EnvironmentObject private var account: StremioAccount
+    @EnvironmentObject private var theme: ThemeManager
+    @State private var showingLogin = false
 
     var body: some View {
         VStack(spacing: Theme.Space.md) {
@@ -516,9 +520,21 @@ struct CoreEmptyState: View {
                 .multilineTextAlignment(.center)
                 .lineSpacing(4)
                 .frame(maxWidth: 760)
+            if showsSignInButton {
+                Button {
+                    showingLogin = true
+                } label: {
+                    Label("Sign In", systemImage: "person.crop.circle")
+                }
+                .buttonStyle(PrimaryActionStyle())
+                .padding(.top, Theme.Space.sm)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(Theme.Space.screenEdge)
+        .fullScreenCover(isPresented: $showingLogin) {
+            LoginView(account: account)
+        }
     }
 
     /// The standard "you are not signed in" state, shown on the main tabs.
@@ -526,7 +542,8 @@ struct CoreEmptyState: View {
         CoreEmptyState(
             systemImage: "person.crop.circle.badge.questionmark",
             title: "Sign in to get started",
-            message: "Open the Settings tab and sign in to your Stremio account to load your library, catalogs, and add-ons."
+            message: "Sign in to your Stremio account to load your library, catalogs, and add-ons.",
+            showsSignInButton: true
         )
     }
 }


### PR DESCRIPTION
- Also fixes issue where icon theme colour wouldn't update when you changed the theme

| Before | After |
|--------|--------|
| <img width="3840" height="2160" alt="Screenshot 2026-06-10 at 19 01 01" src="https://github.com/user-attachments/assets/064634b5-1c70-47c4-8393-c87221b6d407" /> | <img width="3840" height="2160" alt="Screenshot 2026-06-10 at 18 55 55" src="https://github.com/user-attachments/assets/0ba61a4b-3868-4940-be4b-01076820bf94" /> | 

## Sign in page after clicking button (no changes)
<img width="3840" height="2160" alt="Screenshot 2026-06-10 at 18 56 06" src="https://github.com/user-attachments/assets/8a2ec22f-780e-417e-bc7a-02af61539517" />

