### PR TITLE
chore: Allow code signing for xcode builds

### DIFF
--- a/app/project.yml
+++ b/app/project.yml
@@ -41,7 +41,7 @@ targets:
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"
         INFOPLIST_KEY_UIStatusBarStyle: UIStatusBarStyleLightContent
         INFOPLIST_KEY_UIRequiresFullScreen: "YES"
-        CODE_SIGNING_ALLOWED: "NO"
+        CODE_SIGNING_ALLOWED: "YES"
         CODE_SIGNING_REQUIRED: "NO"
   # tvOS has NO WebKit, so this is a native client (SwiftUI + addon HTTP + libmpv),
   # NOT the iOS web-host app. It shares only the MPVKit player core (Sources/Player).
@@ -50,7 +50,7 @@ targets:
     platform: tvOS
     sources:
       - SourcesTV
-      - SourcesShared      # OS-agnostic layer: engine bridge, models, account, ranking, themes
+      - SourcesShared # OS-agnostic layer: engine bridge, models, account, ranking, themes
       - Sources/Player
       - Sources/NodeServer.swift
       - ResourcesTV/Assets.xcassets
@@ -84,7 +84,7 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon & Top Shelf Image"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_FILE: ResourcesTV/Info-tvOS.plist
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"   # explicit UIScene adoption (tvOS 26 compliance)
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES" # explicit UIScene adoption (tvOS 26 compliance)
         INFOPLIST_KEY_CFBundleDisplayName: StremioX
-        CODE_SIGNING_ALLOWED: "NO"
+        CODE_SIGNING_ALLOWED: "YES"
         CODE_SIGNING_REQUIRED: "NO"


### PR DESCRIPTION
I'm not sure if this will have any other side effects for other builds, but I needed this in order to build directly from xcode to Apple TV