### PR TITLE
feat(tvos): improve search page with live suggestions

### DIFF
--- a/app/SourcesShared/CoreBridge.swift
+++ b/app/SourcesShared/CoreBridge.swift
@@ -21,6 +21,7 @@ final class CoreBridge: ObservableObject {
     @Published private(set) var discover: CoreDiscover?
     @Published private(set) var library: CoreLibrary?
     @Published private(set) var searchResults: [CoreMeta] = []
+    @Published private(set) var searchSuggestions: [CoreSearchSuggestion] = []
     @Published private(set) var addons: [CoreDescriptor] = []
 
     /// Raw addon descriptors keyed by transportUrl, kept so we can round-trip a full Descriptor back
@@ -250,6 +251,20 @@ final class CoreBridge: ObservableObject {
         dispatch(action: ["action": "CatalogsWithExtra",
                           "args": ["action": "LoadRange", "args": ["start": 0, "end": 30]]],
                  field: "search")
+    }
+
+    /// Load Cinemeta's local-search index and ask it for autocomplete suggestions as the user types.
+    func loadSearchSuggestions() {
+        dispatch(action: ["action": "Load", "args": ["model": "LocalSearch"]], field: "local_search")
+    }
+
+    func suggestSearch(_ query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        DispatchQueue.main.async { [weak self] in self?.searchSuggestions = [] }
+        guard trimmed.count >= 2 else { return }
+        dispatch(action: ["action": "Search",
+                          "args": ["searchQuery": trimmed, "maxResults": 10]],
+                 field: "local_search")
     }
 
     private static func encodeToDict<T: Encodable>(_ value: T) -> [String: Any]? {
@@ -708,6 +723,10 @@ final class CoreBridge: ObservableObject {
             var seen = Set<String>(); var unique: [CoreMeta] = []
             for item in items where seen.insert(item.id).inserted { unique.append(item) }
             DispatchQueue.main.async { [weak self] in self?.searchResults = unique }
+        }
+        if fields.contains("local_search") {
+            let value = decode(CoreLocalSearchState.self, field: "local_search")
+            DispatchQueue.main.async { [weak self] in self?.searchSuggestions = value?.searchResults ?? [] }
         }
 
         DispatchQueue.main.async { [weak self] in

--- a/app/SourcesShared/CoreBridge.swift
+++ b/app/SourcesShared/CoreBridge.swift
@@ -21,6 +21,7 @@ final class CoreBridge: ObservableObject {
     @Published private(set) var discover: CoreDiscover?
     @Published private(set) var library: CoreLibrary?
     @Published private(set) var searchResults: [CoreMeta] = []
+    @Published private(set) var searchIsLoading = false
     @Published private(set) var searchSuggestions: [CoreSearchSuggestion] = []
     @Published private(set) var addons: [CoreDescriptor] = []
 
@@ -242,8 +243,11 @@ final class CoreBridge: ObservableObject {
     /// extra). Results land in `searchResults`, flattened and de-duplicated into one grid.
     func search(_ query: String) {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        DispatchQueue.main.async { [weak self] in self?.searchResults = [] }
-        guard trimmed.count >= 2 else { return }
+        setSearchLoading(trimmed.count >= 2)
+        guard trimmed.count >= 2 else {
+            DispatchQueue.main.async { [weak self] in self?.searchResults = [] }
+            return
+        }
         dispatch(action: ["action": "Load",
                           "args": ["model": "CatalogsWithExtra",
                                    "args": ["type": NSNull(), "extra": [["search", trimmed]]]]],
@@ -251,6 +255,14 @@ final class CoreBridge: ObservableObject {
         dispatch(action: ["action": "CatalogsWithExtra",
                           "args": ["action": "LoadRange", "args": ["start": 0, "end": 30]]],
                  field: "search")
+    }
+
+    private func setSearchLoading(_ loading: Bool) {
+        if Thread.isMainThread {
+            searchIsLoading = loading
+        } else {
+            DispatchQueue.main.async { [weak self] in self?.searchIsLoading = loading }
+        }
     }
 
     /// Load Cinemeta's local-search index and ask it for autocomplete suggestions as the user types.
@@ -719,10 +731,20 @@ final class CoreBridge: ObservableObject {
         }
         if fields.contains("search") {
             let board = decode(CoreBoardState.self, field: "search")
-            let items = board?.catalogs.flatMap { page in page.compactMap { $0.content?.ready }.flatMap { $0 } } ?? []
+            let pages = board?.catalogs.flatMap { $0 } ?? []
+            let hasLoadingPages = pages.isEmpty || pages.contains { page in
+                guard let content = page.content else { return true }
+                return content.isLoading
+            }
+            let items = pages.compactMap { $0.content?.ready }.flatMap { $0 }
             var seen = Set<String>(); var unique: [CoreMeta] = []
             for item in items where seen.insert(item.id).inserted { unique.append(item) }
-            DispatchQueue.main.async { [weak self] in self?.searchResults = unique }
+            DispatchQueue.main.async { [weak self] in
+                self?.searchIsLoading = hasLoadingPages
+                if !hasLoadingPages || !unique.isEmpty {
+                    self?.searchResults = unique
+                }
+            }
         }
         if fields.contains("local_search") {
             let value = decode(CoreLocalSearchState.self, field: "local_search")

--- a/app/SourcesShared/CoreModels.swift
+++ b/app/SourcesShared/CoreModels.swift
@@ -75,6 +75,7 @@ enum CoreLoadable<T: Decodable>: Decodable {
     }
 
     var ready: T? { if case let .ready(value) = self { return value } else { return nil } }
+    var isLoading: Bool { if case .loading = self { return true } else { return false } }
 }
 
 struct CoreMeta: Decodable, Identifiable {

--- a/app/SourcesShared/CoreModels.swift
+++ b/app/SourcesShared/CoreModels.swift
@@ -92,6 +92,18 @@ struct CoreMeta: Decodable, Identifiable {
     let genres: [String]?
 }
 
+struct CoreLocalSearchState: Decodable {
+    let searchResults: [CoreSearchSuggestion]
+}
+
+struct CoreSearchSuggestion: Decodable, Identifiable {
+    let id: String
+    let name: String
+    let type: String
+    let poster: String?
+    let releaseInfo: String?
+}
+
 // MARK: ctx (only what we need: addon manifests for catalog row titles)
 
 struct CoreCtx: Decodable {

--- a/app/SourcesTV/SearchView.swift
+++ b/app/SourcesTV/SearchView.swift
@@ -6,7 +6,7 @@ struct SearchView: View {
     @EnvironmentObject private var theme: ThemeManager
     @EnvironmentObject private var account: StremioAccount
     @State private var query = ""
-    private let columns = Array(repeating: GridItem(.fixed(kPosterWidth), spacing: Theme.Space.lg), count: 6)
+    @State private var searchTask: Task<Void, Never>?
 
     var body: some View {
         Group {
@@ -16,42 +16,114 @@ struct SearchView: View {
     }
 
     private var results: some View {
-        VStack(alignment: .leading, spacing: Theme.Space.lg) {
-            Text("Search").screenTitleStyle()
-                .padding(.horizontal, Theme.Space.screenEdge).padding(.top, Theme.Space.lg)
-            searchField
-            ScrollView {
-                if core.searchResults.isEmpty {
-                    Text(query.isEmpty ? "Search across everything your addons cover."
-                                       : "No matches for \"\(query)\".")
-                        .font(Theme.Typography.body)
-                        .foregroundStyle(Theme.Palette.textTertiary)
-                        .frame(maxWidth: .infinity).padding(.top, Theme.Space.xxl)
-                } else {
-                    LazyVGrid(columns: columns, spacing: Theme.Space.xl) {
-                        ForEach(core.searchResults) { item in
-                            PosterCard(title: item.name, poster: item.poster, type: item.type, id: item.id,
-                                       menu: .catalog)
-                        }
-                    }
-                    .padding(.horizontal, Theme.Space.screenEdge).padding(.top, Theme.Space.sm)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Space.lg) {
+                resultGrid
+            }
+            .padding(.horizontal, Theme.Space.screenEdge)
+            .padding(.top, Theme.Space.lg)
+            .padding(.bottom, Theme.Space.xl)
+        }
+        .searchable(text: $query, prompt: "Movies or series")
+        .searchSuggestions {
+            ForEach(suggestionTitles, id: \.self) { title in
+                Text(title).searchCompletion(title)
+            }
+        }
+        .onSubmit(of: .search) {
+            searchTask?.cancel()
+            core.suggestSearch(query)
+            searchNow(query)
+        }
+        .onAppear { core.loadSearchSuggestions() }
+        .onChange(of: query) { _, value in scheduleSearch(value) }
+        .onDisappear { searchTask?.cancel() }
+    }
+
+    @ViewBuilder private var resultGrid: some View {
+        if core.searchResults.isEmpty {
+            Text(emptyText)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Palette.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, Theme.Space.xl)
+        } else {
+            VStack(alignment: .leading, spacing: Theme.Space.xl) {
+                ForEach(resultSections, id: \.title) { section in
+                    resultRow(title: section.title, items: section.items)
                 }
             }
         }
     }
 
-    private var searchField: some View {
-        HStack(spacing: Theme.Space.sm) {
-            Image(systemName: "magnifyingglass").foregroundStyle(Theme.Palette.textTertiary)
-            TextField("Movies, series, anything your addons cover", text: $query)
-                .textFieldStyle(.plain)
-                .foregroundStyle(Theme.Palette.textPrimary)
-                .onSubmit { core.search(query) }
+    private func resultRow(title: String, items: [CoreMeta]) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+            Text(title).sectionTitleStyle()
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: Theme.Space.lg) {
+                    ForEach(items) { item in
+                        PosterCard(title: item.name, poster: item.poster, type: item.type, id: item.id,
+                                   menu: .catalog)
+                    }
+                }
+                .padding(.vertical, Theme.Space.sm)
+            }
         }
-        .font(Theme.Typography.body)
-        .padding(.horizontal, Theme.Space.md)
-        .padding(.vertical, Theme.Space.sm)
-        .background(Theme.Palette.surface1, in: RoundedRectangle(cornerRadius: Theme.Radius.control, style: .continuous))
-        .padding(.horizontal, Theme.Space.screenEdge)
+    }
+
+    private var resultSections: [(title: String, items: [CoreMeta])] {
+        let movies = core.searchResults.filter { $0.type == "movie" }
+        let series = core.searchResults.filter { $0.type == "series" }
+        let other = core.searchResults.filter { $0.type != "series" && $0.type != "movie" }
+        return [
+            ("Movies", movies),
+            ("Series", series),
+            ("Other", other),
+        ].filter { !$0.items.isEmpty }
+    }
+
+    private var emptyText: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "Start typing to search across everything your add-ons cover."
+            : "No matches for \"\(query)\"."
+    }
+
+    private var suggestionTitles: [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        var seen = Set<String>()
+
+        let coreSuggestions = core.searchSuggestions.map(\.name)
+            .filter { title in
+                guard title.caseInsensitiveCompare(trimmed) != .orderedSame else { return false }
+                return seen.insert(title).inserted
+            }
+
+        let localTitles = core.searchResults.map(\.name)
+            + core.continueWatching.map(\.name)
+            + core.boardRows.flatMap { $0.items.map(\.name) }
+        let localMatches = localTitles.filter { title in
+            guard title.caseInsensitiveCompare(trimmed) != .orderedSame else { return false }
+            guard title.range(of: trimmed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
+                return false
+            }
+            return seen.insert(title).inserted
+        }
+
+        return Array((coreSuggestions + localMatches).prefix(10))
+    }
+
+    private func scheduleSearch(_ value: String) {
+        searchTask?.cancel()
+        searchTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(350))
+            guard !Task.isCancelled else { return }
+            core.suggestSearch(value)
+            searchNow(value)
+        }
+    }
+
+    private func searchNow(_ value: String) {
+        core.search(value)
     }
 }

--- a/app/SourcesTV/SearchView.swift
+++ b/app/SourcesTV/SearchView.swift
@@ -7,6 +7,7 @@ struct SearchView: View {
     @EnvironmentObject private var account: StremioAccount
     @State private var query = ""
     @State private var searchTask: Task<Void, Never>?
+    @State private var searchDebouncePending = false
 
     var body: some View {
         Group {
@@ -41,12 +42,8 @@ struct SearchView: View {
     }
 
     @ViewBuilder private var resultGrid: some View {
-        if core.searchResults.isEmpty {
-            Text(emptyText)
-                .font(Theme.Typography.body)
-                .foregroundStyle(Theme.Palette.textTertiary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, Theme.Space.xl)
+        if !hasSearchQuery || core.searchResults.isEmpty {
+            emptyState
         } else {
             VStack(alignment: .leading, spacing: Theme.Space.xl) {
                 ForEach(resultSections, id: \.title) { section in
@@ -54,6 +51,20 @@ struct SearchView: View {
                 }
             }
         }
+    }
+
+    private var emptyState: some View {
+        HStack(spacing: Theme.Space.sm) {
+            if isWaitingForCurrentQuery {
+                ProgressView()
+                    .tint(Theme.Palette.accent)
+            }
+            Text(emptyText)
+        }
+        .font(Theme.Typography.body)
+        .foregroundStyle(Theme.Palette.textTertiary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Theme.Space.xl)
     }
 
     private func resultRow(title: String, items: [CoreMeta]) -> some View {
@@ -83,9 +94,18 @@ struct SearchView: View {
     }
 
     private var emptyText: String {
-        query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if isWaitingForCurrentQuery { return "Searching..." }
+        return query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "Start typing to search across everything your add-ons cover."
             : "No matches for \"\(query)\"."
+    }
+
+    private var isWaitingForCurrentQuery: Bool {
+        hasSearchQuery && (searchDebouncePending || core.searchIsLoading)
+    }
+
+    private var hasSearchQuery: Bool {
+        query.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
     }
 
     private var suggestionTitles: [String] {
@@ -115,11 +135,13 @@ struct SearchView: View {
 
     private func scheduleSearch(_ value: String) {
         searchTask?.cancel()
+        searchDebouncePending = value.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
         searchTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(350))
             guard !Task.isCancelled else { return }
             core.suggestSearch(value)
             searchNow(value)
+            searchDebouncePending = false
         }
     }
 


### PR DESCRIPTION
- Quicker access to search
- Search suggestions
- Instant results
- Split between series and movies

The stremio api returns 12 movies and 12 series for a search with no rank between movies vs tv, meaning before if you searched for a series then you would find the top results in the 13 position. Splitting them seems to be the best option as we lack a rank.

| Header |
|--------|
| Before 1 |
| <img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-06-10 at 22 55 07" src="https://github.com/user-attachments/assets/d9e8fba9-7073-4ec4-9a5b-1ef02ceedc37" /> |
| Before 2 |
| <img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-06-10 at 22 55 32" src="https://github.com/user-attachments/assets/8ad04c7c-207d-4861-ad8b-cf5cc2cb05e7" /> |
| After | 
| <img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-06-10 at 22 32 56 (1)" src="https://github.com/user-attachments/assets/95d422a2-c6e0-4d18-93ca-cbe783835cdb" /> | 
