### PR TITLE
feat(tvos): Reuse accent colours on new profile and secure pin

### DIFF
--- a/app/SourcesTV/ProfilesView.swift
+++ b/app/SourcesTV/ProfilesView.swift
@@ -82,6 +82,7 @@ struct ProfilePickerView: View {
                     .foregroundStyle(Theme.Palette.textPrimary)
                 SecureField("PIN", text: $pinInput)
                     .font(Theme.Typography.body)
+                    .keyboardType(.numberPad)
                     .frame(width: 360)
                     .onChange(of: pinInput) {
                         pinInput = String(pinInput.filter(\.isNumber).prefix(4))
@@ -257,20 +258,8 @@ struct ProfileEditorView: View {
                         .frame(width: 64, height: 64)
                     }
 
-                    row("Accent") {
-                        ForEach(ThemeManager.accents) { option in
-                            Button(option.label) { draft.accentID = option.id }
-                                .buttonStyle(ChipButtonStyle(selected: draft.accentID == option.id,
-                                                             accent: option.base))
-                        }
-                    }
-
-                    row("Background") {
-                        Button("Warm") { draft.oled = false }
-                            .buttonStyle(ChipButtonStyle(selected: !draft.oled))
-                        Button("OLED Black") { draft.oled = true }
-                            .buttonStyle(ChipButtonStyle(selected: draft.oled))
-                    }
+                    ThemeAccentPicker(selection: $draft.accentID)
+                    ThemeBackgroundPicker(oled: $draft.oled)
 
                     if draft.isOwner {
                         // The owner IS the main account; offering "its own account" here once
@@ -298,8 +287,9 @@ struct ProfileEditorView: View {
                     }
 
                     row("PIN") {
-                        TextField("4 digits, empty for none", text: $pinText)
+                        SecureField("4 digits, empty for none", text: $pinText)
                             .font(Theme.Typography.body)
+                            .keyboardType(.numberPad)
                             .frame(width: 600)
                             .onChange(of: pinText) {
                                 pinText = String(pinText.filter(\.isNumber).prefix(4))

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -169,22 +169,8 @@ struct SettingsView: View {
 
     private var appearanceSection: some View {
         section("Appearance") {
-            Text("Accent").font(Theme.Typography.cardTitle).foregroundStyle(Theme.Palette.textPrimary)
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Space.md) {
-                    ForEach(ThemeManager.accents) { opt in
-                        Button { theme.accentID = opt.id } label: {
-                            AccentCircle(color: opt.base, selected: theme.accentID == opt.id)
-                        }
-                        .buttonStyle(CardFocusStyle())
-                    }
-                }
-                .padding(.horizontal, Theme.Space.sm)
-                .padding(.vertical, Theme.Space.xs)
-            }
-            choiceRow("Background", [("warm", "Warm"), ("oled", "OLED Black")],
-                      selection: Binding(get: { theme.oled ? "oled" : "warm" },
-                                         set: { theme.oled = ($0 == "oled") }))
+            ThemeAccentPicker(selection: $theme.accentID)
+            ThemeBackgroundPicker(oled: $theme.oled)
             Text("Accent recolors focus, selection, and progress across the app. OLED Black uses true black, best on AMOLED panels.")
                 .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
         }
@@ -280,6 +266,44 @@ struct SettingsView: View {
             Text(value).foregroundStyle(Theme.Palette.textSecondary)
         }
         .font(Theme.Typography.body)
+    }
+}
+
+struct ThemeAccentPicker: View {
+    @Binding var selection: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+            Text("Accent").font(Theme.Typography.cardTitle).foregroundStyle(Theme.Palette.textPrimary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.Space.md) {
+                    ForEach(ThemeManager.accents) { opt in
+                        Button { selection = opt.id } label: {
+                            AccentCircle(color: opt.base, selected: selection == opt.id)
+                        }
+                        .buttonStyle(CardFocusStyle())
+                    }
+                }
+                .padding(.horizontal, Theme.Space.sm)
+                .padding(.vertical, Theme.Space.xs)
+            }
+        }
+    }
+}
+
+struct ThemeBackgroundPicker: View {
+    @Binding var oled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+            Text("Background").font(Theme.Typography.cardTitle).foregroundStyle(Theme.Palette.textPrimary)
+            HStack(spacing: Theme.Space.sm) {
+                Button("Warm") { oled = false }
+                    .buttonStyle(ChipButtonStyle(selected: !oled))
+                Button("OLED Black") { oled = true }
+                    .buttonStyle(ChipButtonStyle(selected: oled))
+            }
+        }
     }
 }
 


### PR DESCRIPTION

## What and why

- reuse accent colours and style on the new profile page
- show numeric pad for pin entry rather than full keyboard
- set pin as a secure field
- previously you could just view someone's pin by going to their profile settings. It's still possible to change someone's pin and then login, but then the person would know you did it. You could lock down the settings page with the pin, but there is the risk you forget it and have no way to delete that profile.

## Screenshots

| Before | After |
|--------|--------|
| <img width="582" height="466" alt="image" src="https://github.com/user-attachments/assets/a1e0c70b-9567-4dba-8f91-9ede672b3d3b" /> | <img width="603" height="487" alt="image" src="https://github.com/user-attachments/assets/38e1f01f-00e8-4121-b9d9-b0a37277e748" /> |
| <img width="499" height="300" alt="image" src="https://github.com/user-attachments/assets/f1e1dd3d-e030-49b9-94bc-b767a0669d59" /> | <img width="491" height="300" alt="image" src="https://github.com/user-attachments/assets/d6b53798-9793-40be-b796-9adc2d3a83b0" /> | 
| <img width="980" height="477" alt="image" src="https://github.com/user-attachments/assets/ab978419-c80c-425b-be53-c2a62a08c5b4" /> | <img width="462" height="391" alt="image" src="https://github.com/user-attachments/assets/5b226000-210d-4d01-86c5-99ee416c02fa" /> | 


## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [x] Screenshots attached for UI changes
