### PR TITLE
chore: fix build cache

### DIFF
--- a/.github/workflows/release-tvos.yml
+++ b/.github/workflows/release-tvos.yml
@@ -7,6 +7,15 @@ name: Release tvOS IPA
 # stremio-core engine built from the core/ crate in this repo.
 
 on:
+  # Release-tag caches are isolated per tag, so seed the same exact cache key on
+  # main where later release runs can restore it from the default-branch scope.
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-tvos.yml"
+      - "app/**"
+      - "core/**"
+      - "scripts/**"
   release:
     types: [published]
   workflow_dispatch:

--- a/scripts/build-core-xcframework.sh
+++ b/scripts/build-core-xcframework.sh
@@ -6,7 +6,6 @@
 set -euo pipefail
 cd "$(dirname "$0")/../core"
 source "$HOME/.cargo/env" 2>/dev/null || true
-export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 
 BUILDSTD="-Z build-std=std,panic_abort"
 LIB="libstremiox_core.a"


### PR DESCRIPTION
## What and why

- the GitHub isolation rules for cache mean that cache created in a release tag will never be used for another release from the `main` branch.
- to fix, we generate the cache on the `main` branch when something relevant changes, then that can be used by the release tag
- removed `DEVELOPER_DIR` export as this could cause issues with the version used for the build which should come from `xcode-select -p`

The cache key was always the same for the recent releases, but never got a hit because of the issue above.
