### PR TITLE
feat(tvos): add option to disable torrents 

### DIFF
--- a/.github/workflows/release-tvos.yml
+++ b/.github/workflows/release-tvos.yml
@@ -13,7 +13,6 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/release-tvos.yml"
-      - "app/**"
       - "core/**"
       - "scripts/**"
   release:
@@ -85,28 +84,40 @@ jobs:
           xcodebuild -project StremioX.xcodeproj -scheme StremioXTV \
             -configuration Release -destination 'generic/platform=tvOS' \
             -derivedDataPath build/ci CODE_SIGNING_ALLOWED=NO build
+          xcodebuild -project StremioX.xcodeproj -scheme StremioXTVDirect \
+            -configuration Release -destination 'generic/platform=tvOS' \
+            -derivedDataPath build/ci-direct CODE_SIGNING_ALLOWED=NO build
 
-      - name: Package the IPA
+      - name: Package the IPAs
         run: |
-          mkdir -p out/Payload
-          cp -R app/build/ci/Build/Products/Release-appletvos/StremioXTV.app out/Payload/
-          cd out
-          zip -qry StremioX-tvOS-ci.ipa Payload
-          shasum -a 256 StremioX-tvOS-ci.ipa | tee SHA256SUMS-ci.txt
+          mkdir -p out/full/Payload out/direct/Payload
+          cp -R app/build/ci/Build/Products/Release-appletvos/StremioXTV.app out/full/Payload/
+          cp -R app/build/ci-direct/Build/Products/Release-appletvos/StremioXTVDirect.app out/direct/Payload/
+          (cd out/full && zip -qry ../StremioX-tvOS-ci.ipa Payload)
+          (cd out/direct && zip -qry ../StremioX-tvOS-direct-ci.ipa Payload)
+          shasum -a 256 out/StremioX-tvOS-ci.ipa out/StremioX-tvOS-direct-ci.ipa | tee out/SHA256SUMS-ci.txt
 
       - name: Upload artifact (manual runs)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: StremioX-tvOS-ci
-          path: out/StremioX-tvOS-ci.ipa
+          path: |
+            out/StremioX-tvOS-ci.ipa
+            out/StremioX-tvOS-direct-ci.ipa
+            out/SHA256SUMS-ci.txt
 
-      - name: Attach the CI build to the release
+      - name: Attach the CI builds to the release
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
           mv out/StremioX-tvOS-ci.ipa "out/StremioX-tvOS-$TAG-ci.ipa"
-          shasum -a 256 "out/StremioX-tvOS-$TAG-ci.ipa" > out/SHA256SUMS-ci.txt
-          gh release upload "$TAG" "out/StremioX-tvOS-$TAG-ci.ipa" out/SHA256SUMS-ci.txt --clobber
+          mv out/StremioX-tvOS-direct-ci.ipa "out/StremioX-tvOS-direct-$TAG-ci.ipa"
+          shasum -a 256 "out/StremioX-tvOS-$TAG-ci.ipa" "out/StremioX-tvOS-direct-$TAG-ci.ipa" > out/SHA256SUMS-ci.txt
+          gh release upload "$TAG" \
+            "out/StremioX-tvOS-$TAG-ci.ipa" \
+            "out/StremioX-tvOS-direct-$TAG-ci.ipa" \
+            out/SHA256SUMS-ci.txt \
+            --clobber

--- a/app/Sources/NodeServer.swift
+++ b/app/Sources/NodeServer.swift
@@ -13,6 +13,7 @@ enum NodeServer {
 
     /// One-line state for the Settings diagnostics.
     static var statusDescription: String {
+        if PlaybackSettings.torrentsDisabled { return "Disabled by Direct Links Only" }
         if !started { return "Not started (server.js missing from the bundle)" }
         if let code = exitCode { return "Server exited with code \(code). Relaunch the app to restart it." }
         return "Server process running"

--- a/app/Sources/Player/TrackPreferences.swift
+++ b/app/Sources/Player/TrackPreferences.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+enum PlaybackSettings {
+    enum Key {
+        static let directLinksOnly = "stremiox.directLinksOnly"
+    }
+
+    static var directLinksOnlyForced: Bool {
+        #if STREMIOX_NO_EMBEDDED_SERVER
+        true
+        #else
+        false
+        #endif
+    }
+
+    static var directLinksOnly: Bool {
+        #if STREMIOX_NO_EMBEDDED_SERVER
+        true
+        #else
+        UserDefaults.standard.bool(forKey: Key.directLinksOnly)
+        #endif
+    }
+
+    static var torrentsDisabled: Bool { directLinksOnly }
+}
+
 /// What audio and subtitle track the player should pick automatically. Persisted in UserDefaults and
 /// shared by the iOS and tvOS players; configured from tvOS Settings, with sensible defaults until then.
 struct TrackPreferences: Equatable {

--- a/app/Sources/StremioWebView.swift
+++ b/app/Sources/StremioWebView.swift
@@ -133,6 +133,10 @@ struct StremioWebView: UIViewRepresentable {
         /// libmpv reaches http://127.0.0.1:11470 directly (not a web context, no mixed-content,
         /// which is why this can't be done from the WKWebView's JS).
         private func handleTorrent(infoHash: String, fileIdx: Int?, sources: [String]) {
+            guard !PlaybackSettings.torrentsDisabled else {
+                log.info("torrent capture ignored: Direct Links Only is enabled")
+                return
+            }
             let ih = infoHash.lowercased()
             let base = "http://127.0.0.1:11470"
             var srcs = sources

--- a/app/Sources/StremioXApp.swift
+++ b/app/Sources/StremioXApp.swift
@@ -8,7 +8,8 @@ struct StremioXApp: App {
         // torrent / non-web-ready streams the server must fetch & remux can play. Direct debrid
         // streams play without it (native libmpv + UA), but the server is needed for full parity.
         // On by default; -stremiox-no-server disables it for isolation testing.
-        if !ProcessInfo.processInfo.arguments.contains("-stremiox-no-server") {
+        if !PlaybackSettings.torrentsDisabled,
+           !ProcessInfo.processInfo.arguments.contains("-stremiox-no-server") {
             NodeServer.startIfNeeded()
         }
         #endif

--- a/app/SourcesShared/Addon.swift
+++ b/app/SourcesShared/Addon.swift
@@ -70,7 +70,7 @@ struct Stream: Identifiable, Decodable, Hashable {
     /// Short tag the addon shows (addon name + quality), e.g. "Torrentio\n1080p".
     var heading: String { (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines) }
     /// Direct/debrid URLs play in libmpv; torrents (infoHash) play via the embedded server.
-    var isPlayable: Bool { url != nil || infoHash != nil }
+    var isPlayable: Bool { url != nil || (!PlaybackSettings.torrentsDisabled && infoHash != nil) }
     var isTorrent: Bool { url == nil && infoHash != nil }
 }
 

--- a/app/SourcesShared/CoreModels.swift
+++ b/app/SourcesShared/CoreModels.swift
@@ -266,6 +266,7 @@ struct CoreStream: Decodable, Identifiable {
     /// Direct/debrid URLs play as-is; torrents go through the embedded streaming server.
     var playableURL: URL? {
         if let url, let parsed = URL(string: url) { return parsed }
+        guard !PlaybackSettings.torrentsDisabled else { return nil }
         guard let hash = infoHash?.lowercased() else { return nil }
         return URL(string: "\(StremioServer.base)/\(hash)/\(fileIdx ?? 0)")
     }

--- a/app/SourcesShared/StremioServer.swift
+++ b/app/SourcesShared/StremioServer.swift
@@ -55,6 +55,7 @@ enum StremioServer {
     /// torrent. Pure (no side effects); call `prepare(_:)` to actually create the torrent.
     static func resolveURL(for stream: Stream) -> URL? {
         if let u = stream.url, let url = URL(string: u) { return url }
+        guard !PlaybackSettings.torrentsDisabled else { return nil }
         guard let ih = stream.infoHash?.lowercased() else { return nil }
         return URL(string: "\(base)/\(ih)/\(stream.fileIdx ?? 0)")
     }
@@ -62,6 +63,7 @@ enum StremioServer {
     /// For torrents, tell the server to create the torrent (start fetching peers) before playback.
     /// No-op for direct/debrid streams. Fire-and-forget, the file endpoint blocks until ready.
     static func prepare(_ stream: Stream) {
+        guard !PlaybackSettings.torrentsDisabled else { return }
         guard stream.url == nil, let ih = stream.infoHash?.lowercased(),
               let url = URL(string: "\(base)/\(ih)/create") else { return }
         var sources = stream.sources ?? []

--- a/app/SourcesTV/DetailView.swift
+++ b/app/SourcesTV/DetailView.swift
@@ -550,9 +550,10 @@ struct CoreStreamList: View {
     @State private var qualityTier: String? = nil  // level 2: pick a flavor inside that tier
     @State private var settleTimedOut = false      // opens the Watch-Now gate even if an add-on hangs
     @EnvironmentObject private var presenter: PlayerPresenter   // root-replacement player presentation
+    @AppStorage(PlaybackSettings.Key.directLinksOnly) private var directLinksOnly = false
 
     var body: some View {
-        let groups = StreamRanking.rankedGroups(core.streamGroups())   // best source first within each add-on
+        let groups = StreamRanking.rankedGroups(displayGroups(core.streamGroups()))   // best source first within each add-on
         let streamCount = groups.reduce(0) { $0 + $1.streams.count }
         let visible = groups.filter { sourceFilter == nil || $0.addon == sourceFilter }
         let addons = core.streamLoadProgress()                       // (loaded, total) stream add-ons
@@ -673,6 +674,15 @@ struct CoreStreamList: View {
         }
     }
 
+    private func displayGroups(_ groups: [CoreStreamSourceGroup]) -> [CoreStreamSourceGroup] {
+        guard directLinksOnly else { return groups }
+        return groups.compactMap { group in
+            let streams = group.streams.filter { !$0.isTorrent }
+            guard !streams.isEmpty else { return nil }
+            return CoreStreamSourceGroup(id: group.id, addon: group.addon, streams: streams)
+        }
+    }
+
     /// Play a stream by handing a request to the root, which swaps the whole shell out for the player
     /// (the only reliable tvOS focus isolation — see RootView). Wires the engine + prepares torrents first.
     private func play(_ stream: CoreStream) {
@@ -744,6 +754,7 @@ struct CoreStreamList: View {
 
     /// Torrents: ask the embedded server to start fetching peers before playback. No-op for url/debrid.
     private func prepareTorrent(_ stream: CoreStream) {
+        guard !PlaybackSettings.torrentsDisabled else { return }
         guard stream.url == nil, let hash = stream.infoHash?.lowercased(),
               let url = URL(string: "\(StremioServer.base)/\(hash)/create") else { return }
         var sources = stream.sources ?? []

--- a/app/SourcesTV/HomeView.swift
+++ b/app/SourcesTV/HomeView.swift
@@ -140,6 +140,7 @@ struct CoreContinueWatchingRow: View {
     private func directResume(_ item: CoreCWItem) -> (() -> Void)? {
         guard let entry = LastStreamStore.entry(for: item.id, profileID: profiles.activeID),
               let url = URL(string: entry.url) else { return nil }
+        if PlaybackSettings.torrentsDisabled && entry.torrent == true { return nil }
         if item.type == "series", let cwVideo = item.state.videoId, cwVideo != entry.videoId { return nil }
         return {
             presenter.request = PlaybackRequest(

--- a/app/SourcesTV/OpenLinkView.swift
+++ b/app/SourcesTV/OpenLinkView.swift
@@ -9,16 +9,19 @@ struct OpenLinkView: View {
     @State private var input = ""
     @State private var working = false
     @State private var status: String?
+    @AppStorage(PlaybackSettings.Key.directLinksOnly) private var directLinksOnly = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Space.lg) {
             Text("Play a link")
                 .font(Theme.Typography.sectionTitle)
                 .foregroundStyle(Theme.Palette.textPrimary)
-            Text("A direct video URL (mp4, mkv, m3u8 and friends), a debrid or usenet link your service resolved to http(s), or a magnet link.")
+            Text(directLinksOnly
+                 ? "A direct video URL (mp4, mkv, m3u8 and friends), a debrid or usenet link your service resolved to http(s)."
+                 : "A direct video URL (mp4, mkv, m3u8 and friends), a debrid or usenet link your service resolved to http(s), or a magnet link.")
                 .font(Theme.Typography.body)
                 .foregroundStyle(Theme.Palette.textSecondary)
-            TextField("https://…   magnet:?xt=…   or paste any direct stream link", text: $input)
+            TextField(directLinksOnly ? "https://..." : "https://...  or  magnet:?xt=...", text: $input)
                 .font(Theme.Typography.body)
                 .disableAutocorrection(true)
             HStack(spacing: Theme.Space.md) {
@@ -41,6 +44,10 @@ struct OpenLinkView: View {
     private func play() {
         var text = input.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.lowercased().hasPrefix("magnet:") {
+            guard !PlaybackSettings.torrentsDisabled else {
+                status = "Torrenting is disabled. Use a direct or debrid http(s) link."
+                return
+            }
             guard let magnet = LinkOpener.parseMagnet(text) else {
                 status = "That magnet link has no usable info hash."
                 return
@@ -52,7 +59,9 @@ struct OpenLinkView: View {
         if !text.contains("://"), text.contains(".") { text = "https://" + text }
         guard let url = URL(string: text), let scheme = url.scheme?.lowercased(),
               scheme == "http" || scheme == "https" else {
-            status = "Not a playable link. Paste a direct http(s) stream link (debrid and usenet links count) or a magnet."
+            status = directLinksOnly
+                ? "Not a playable link. Paste a direct http(s) stream link (debrid and usenet links count)."
+                : "Not a playable link. Paste a direct http(s) stream link (debrid and usenet links count) or a magnet."
             return
         }
         let title = url.lastPathComponent.isEmpty ? (url.host ?? "Stream") : url.lastPathComponent
@@ -113,6 +122,7 @@ enum LinkOpener {
     /// metadata is in (it needs at least one peer), with the file list; pick the
     /// biggest video file.
     static func resolveMagnet(_ magnet: Magnet) async -> (url: URL, fileName: String)? {
+        guard !PlaybackSettings.torrentsDisabled else { return nil }
         let sources = TorrentTrackers.sources(forHash: magnet.infoHash,
                                               streamSources: nil,
                                               addonTrackers: magnet.trackers)

--- a/app/SourcesTV/RootTabView.swift
+++ b/app/SourcesTV/RootTabView.swift
@@ -22,7 +22,13 @@ struct PlaybackRequest: Identifiable {
 
 /// Holds the active playback request. Set it to present the player; clear it to dismiss.
 final class PlayerPresenter: ObservableObject {
-    @Published var request: PlaybackRequest?
+    @Published var request: PlaybackRequest? {
+        didSet {
+            if request?.torrent == true && PlaybackSettings.torrentsDisabled {
+                request = nil
+            }
+        }
+    }
 }
 
 /// App root, three focus rules learned the hard way:

--- a/app/SourcesTV/SearchView.swift
+++ b/app/SourcesTV/SearchView.swift
@@ -9,6 +9,7 @@ struct SearchView: View {
     @State private var query = ""
     @State private var searchTask: Task<Void, Never>?
     @State private var searchDebouncePending = false
+    @AppStorage(PlaybackSettings.Key.directLinksOnly) private var directLinksOnly = false
 
     var body: some View {
         Group {
@@ -21,7 +22,7 @@ struct SearchView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: Theme.Space.lg) {
                 Button { showOpenLink = true } label: {
-                    Label("Play a link or magnet", systemImage: "link")
+                    Label(directLinksOnly ? "Play a direct link" : "Play a link or magnet", systemImage: "link")
                 }
                 .buttonStyle(ChipButtonStyle(selected: false))
                 .sheet(isPresented: $showOpenLink) { OpenLinkView() }

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @AppStorage(TrackPreferences.Key.forced) private var prefForced = TrackPreferences.ForcedPolicy.forced.rawValue
     @AppStorage(TrackPreferences.Key.audio) private var prefAudioLang = TrackPreferences.deviceLanguages.first ?? "en"
     @AppStorage(TrackPreferences.Key.subtitle) private var prefSubLang = TrackPreferences.deviceLanguages.first ?? "en"
+    @AppStorage(PlaybackSettings.Key.directLinksOnly) private var directLinksOnly = false
 
     var body: some View {
         NavigationStack {
@@ -26,6 +27,7 @@ struct SettingsView: View {
                     Text("Settings").screenTitleStyle()
                     profilesSection
                     accountSection
+                    playbackSection
                     serverSection
                     appearanceSection
                     audioSubtitleSection
@@ -44,6 +46,11 @@ struct SettingsView: View {
             // the old 24-second window could expire first, showing "Offline" until a relaunch.
             // Retries fast while offline, keeps the badge fresh once up; restarts on each visit.
             while !Task.isCancelled {
+                if effectiveDirectLinksOnly {
+                    serverOnline = nil
+                    try? await Task.sleep(for: .seconds(12))
+                    continue
+                }
                 let online = await StremioServer.isOnline()
                 serverOnline = online
                 try? await Task.sleep(for: .seconds(online ? 12 : 3))
@@ -122,6 +129,57 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: Playback
+
+    private var playbackSection: some View {
+        section("Playback") {
+            if PlaybackSettings.directLinksOnlyForced {
+                directLinksOnlyRow
+                    .background(Theme.Palette.surface1,
+                                in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+            } else {
+                Button { setDirectLinksOnly(!directLinksOnly) } label: {
+                    directLinksOnlyRow
+                }
+                .buttonStyle(RowFocusStyle())
+            }
+        }
+    }
+
+    private var effectiveDirectLinksOnly: Bool {
+        PlaybackSettings.directLinksOnly
+    }
+
+    private var directLinksOnlyRow: some View {
+        HStack(alignment: .center, spacing: Theme.Space.lg) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Direct Links Only")
+                    .font(Theme.Typography.cardTitle)
+                    .foregroundStyle(Theme.Palette.textPrimary)
+                Text(PlaybackSettings.directLinksOnlyForced
+                     ? "This build does not bundle the torrent engine. Only direct and debrid links can play."
+                     : "Hide torrent and magnet sources. Only direct and debrid links will play.")
+                    .font(Theme.Typography.label)
+                    .foregroundStyle(Theme.Palette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: Theme.Space.md)
+            TogglePill(isOn: effectiveDirectLinksOnly, locked: PlaybackSettings.directLinksOnlyForced)
+        }
+        .padding(Theme.Space.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+    }
+
+    private func setDirectLinksOnly(_ value: Bool) {
+        directLinksOnly = value
+        #if !STREMIOX_NO_EMBEDDED_SERVER
+        if !value, !ProcessInfo.processInfo.arguments.contains("-stremiox-no-server") {
+            NodeServer.startIfNeeded()
+        }
+        #endif
+    }
+
     // MARK: Streaming server
 
     private var serverSection: some View {
@@ -130,22 +188,25 @@ struct SettingsView: View {
                 Circle().fill(serverColor).frame(width: 16, height: 16)
                 Text(serverText).font(Theme.Typography.body).foregroundStyle(Theme.Palette.textPrimary)
                 Spacer()
-                Text(StremioServer.isCustom ? "CUSTOM" : "EMBEDDED")
+                Text(PlaybackSettings.directLinksOnlyForced ? "NOT BUNDLED" : (StremioServer.isCustom ? "CUSTOM" : "EMBEDDED"))
                     .font(Theme.Typography.eyebrow).tracking(1)
                     .padding(.horizontal, 12).padding(.vertical, 5)
                     .background(Theme.Palette.surface3, in: Capsule())
                     .foregroundStyle(Theme.Palette.textSecondary)
             }
-            Text(StremioServer.base).font(.system(size: 18, design: .monospaced)).foregroundStyle(Theme.Palette.textTertiary)
+            Text(PlaybackSettings.directLinksOnlyForced ? "Embedded server not bundled" : StremioServer.base)
+                .font(.system(size: 18, design: .monospaced)).foregroundStyle(Theme.Palette.textTertiary)
             // When the embedded server is unreachable, explain itself: node's run state and the
             // server's own last log lines, so a dead server is diagnosable from the couch.
             if serverOnline == false && !StremioServer.isCustom {
+                #if !STREMIOX_NO_EMBEDDED_SERVER
                 Text(NodeServer.statusDescription)
                     .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
                 ForEach(NodeServer.logTail(), id: \.self) { line in
                     Text(line).font(.system(size: 16, design: .monospaced))
                         .foregroundStyle(Theme.Palette.textTertiary).lineLimit(1)
                 }
+                #endif
             }
             // Apple TV has no user-facing force quit, and a dead embedded server can
             // only come back with a fresh process (node starts once per process).
@@ -162,16 +223,19 @@ struct SettingsView: View {
             } message: {
                 Text("The app quits immediately. Open it again from the Home Screen; the streaming server restarts with it.")
             }
-            NavigationLink {
-                ServerConfigView { Task { serverOnline = await StremioServer.isOnline() } }
-            } label: {
-                Label("Configure server", systemImage: "server.rack")
+            if !PlaybackSettings.directLinksOnlyForced {
+                NavigationLink {
+                    ServerConfigView { Task { serverOnline = await StremioServer.isOnline() } }
+                } label: {
+                    Label("Configure server", systemImage: "server.rack")
+                }
+                .buttonStyle(PrimaryActionStyle())
             }
-            .buttonStyle(PrimaryActionStyle())
         }
     }
 
     private var serverColor: Color {
+        if effectiveDirectLinksOnly { return Theme.Palette.textTertiary }
         switch serverOnline {
         case .some(true): return Color(.sRGB, red: 0.45, green: 0.72, blue: 0.42)
         case .some(false): return Theme.Palette.danger
@@ -179,6 +243,7 @@ struct SettingsView: View {
         }
     }
     private var serverText: String {
+        if effectiveDirectLinksOnly { return "Disabled by Direct Links Only" }
         switch serverOnline { case .some(true): return "Online"; case .some(false): return "Offline"; default: return "Checking…" }
     }
 
@@ -291,6 +356,32 @@ struct SettingsView: View {
             Text(value).foregroundStyle(Theme.Palette.textSecondary)
         }
         .font(Theme.Typography.body)
+    }
+}
+
+private struct TogglePill: View {
+    let isOn: Bool
+    var locked: Bool = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(locked ? "Locked" : (isOn ? "On" : "Off"))
+                .font(Theme.Typography.eyebrow)
+                .tracking(1)
+            ZStack(alignment: isOn ? .trailing : .leading) {
+                Capsule()
+                    .fill(isOn ? Theme.Palette.accent.opacity(0.24) : Theme.Palette.surface3)
+                    .frame(width: 64, height: 34)
+                Circle()
+                    .fill(isOn ? Theme.Palette.accent : Theme.Palette.textTertiary)
+                    .frame(width: 24, height: 24)
+                    .padding(.horizontal, 5)
+            }
+        }
+        .foregroundStyle(isOn ? Theme.Palette.accent : Theme.Palette.textSecondary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Theme.Palette.surface2, in: Capsule(style: .continuous))
     }
 }
 

--- a/app/SourcesTV/StremioTVApp.swift
+++ b/app/SourcesTV/StremioTVApp.swift
@@ -11,9 +11,12 @@ struct StremioTVApp: App {
         // Embed Stremio's streaming server on :11470 (nodejs-mobile retargeted to tvOS), so
         // torrent / non-web-ready streams the server must fetch & remux can play on Apple TV.
         // On by default; -stremiox-no-server disables it for isolation testing.
-        if !ProcessInfo.processInfo.arguments.contains("-stremiox-no-server") {
+        #if !STREMIOX_NO_EMBEDDED_SERVER
+        if !PlaybackSettings.torrentsDisabled,
+           !ProcessInfo.processInfo.arguments.contains("-stremiox-no-server") {
             NodeServer.startIfNeeded()
         }
+        #endif
         // Boot the native stremio-core engine (hydrates library/profile from storage, starts the
         // event loop). The schema-version log is an end-to-end smoke check of the Rust⇄Swift FFI.
         CoreBridge.shared.start()

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -1227,6 +1227,7 @@ struct TVPlayerView: View {
 
     /// Torrents: ask the embedded server to start fetching peers before playback. No-op for url/debrid.
     private func prepareTorrent(_ stream: CoreStream) {
+        guard !PlaybackSettings.torrentsDisabled else { return }
         guard stream.url == nil, let hash = stream.infoHash?.lowercased(),
               let url = URL(string: "\(StremioServer.base)/\(hash)/create") else { return }
         let sources = TorrentTrackers.sources(forHash: hash, streamSources: stream.sources)

--- a/app/project.yml
+++ b/app/project.yml
@@ -88,3 +88,63 @@ targets:
         INFOPLIST_KEY_CFBundleDisplayName: StremioX
         CODE_SIGNING_ALLOWED: "YES"
         CODE_SIGNING_REQUIRED: "NO"
+  # Direct/debrid-only tvOS build. This omits NodeMobile and server.js entirely,
+  # so the app cannot create or play torrents even if old preferences say otherwise.
+  StremioXTVDirect:
+    type: application
+    platform: tvOS
+    sources:
+      - SourcesTV
+      - SourcesShared # OS-agnostic layer: engine bridge, models, account, ranking, themes
+      - Sources/Player
+      - ResourcesTV/Assets.xcassets
+      - path: Resources/fonts
+        optional: true
+        type: folder
+        buildPhase: resources
+    dependencies:
+      - package: MPVKit
+        product: MPVKit-GPL
+      # The Rust stremio-core engine (staticlib xcframework), linked, not embedded.
+      - framework: Vendor/StremioXCore.xcframework
+        embed: false
+      - sdk: AVKit.framework
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.stremiox.tv.direct
+        SWIFT_OBJC_BRIDGING_HEADER: Sources/Player/StremioX-Bridging.h
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) STREMIOX_NO_EMBEDDED_SERVER"
+        MARKETING_VERSION: "0.2.31"
+        CURRENT_PROJECT_VERSION: "58"
+        ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon & Top Shelf Image"
+        GENERATE_INFOPLIST_FILE: "YES"
+        INFOPLIST_FILE: ResourcesTV/Info-tvOS.plist
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"
+        INFOPLIST_KEY_CFBundleDisplayName: StremioX Direct
+        CODE_SIGNING_ALLOWED: "YES"
+        CODE_SIGNING_REQUIRED: "NO"
+schemes:
+  StremioX:
+    build:
+      targets:
+        StremioX: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  StremioXTV:
+    build:
+      targets:
+        StremioXTV: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  StremioXTVDirect:
+    build:
+      targets:
+        StremioXTVDirect: all
+    run:
+      config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
## What and why

- If you have a debrid service you probably don't need torrents and accidentally connecting to one adds risk without a vpn, so an option to disable is useful
- I've also added a smaller build which now no longer needs to node service required for torrents

## Screenshots

<img width="958" height="335" alt="image" src="https://github.com/user-attachments/assets/7607c4ae-8bc7-4719-9d36-05580e13c909" />

<img width="969" height="278" alt="image" src="https://github.com/user-attachments/assets/cec8d50d-1bea-411d-8d9a-4a3210d6dcba" />


## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [x] Screenshots attached for UI changes
