### PR TITLE
feat(tvos): add support for playing live streams

### DIFF
--- a/app/Sources/Player/MPVMetalPlayerView.swift
+++ b/app/Sources/Player/MPVMetalPlayerView.swift
@@ -8,6 +8,7 @@ struct MPVMetalPlayerView: UIViewControllerRepresentable {
         let mpv =  MPVMetalViewController()
         mpv.playDelegate = coordinator
         mpv.playUrl = coordinator.playUrl
+        mpv.playUrlLive = coordinator.playLive
         let coord = context.coordinator
         mpv.onSingleTap = { [weak coord] in coord?.onTap?() }
 
@@ -30,6 +31,11 @@ struct MPVMetalPlayerView: UIViewControllerRepresentable {
         coordinator.playUrl = url
         return self
     }
+
+    func live(_ live: Bool) -> Self {
+        coordinator.playLive = live
+        return self
+    }
     
     func onPropertyChange(_ handler: @escaping (MPVMetalViewController, String, Any?) -> Void) -> Self {
         coordinator.onPropertyChange = handler
@@ -46,11 +52,12 @@ struct MPVMetalPlayerView: UIViewControllerRepresentable {
         weak var player: MPVMetalViewController?
         
         var playUrl : URL?
+        var playLive = false
         var onPropertyChange: ((MPVMetalViewController, String, Any?) -> Void)?
         var onTap: (() -> Void)?
         
         func play(_ url: URL) {
-            player?.loadFile(url)
+            player?.loadFile(url, live: playLive)
         }
         
         func propertyChange(mpv: OpaquePointer, propertyName: String, data: Any?) {
@@ -60,4 +67,3 @@ struct MPVMetalPlayerView: UIViewControllerRepresentable {
         }
     }
 }
-

--- a/app/Sources/Player/MPVMetalViewController.swift
+++ b/app/Sources/Player/MPVMetalViewController.swift
@@ -26,9 +26,11 @@ final class MPVMetalViewController: UIViewController {
     lazy var queue = DispatchQueue(label: "mpv", qos: .userInitiated)
     
     var playUrl: URL?
+    var playUrlLive = false
     var onSingleTap: (() -> Void)?
     var hdrAvailable : Bool = false
     private let mpvLog = Logger(subsystem: "com.stremiox.app", category: "mpv")
+    private var configuredLiveMode = false
     /// The dynamic range currently applied to the output chain (mpv transfer curve,
     /// Metal layer colorspace, and on tvOS the display mode). Tracked so the sig-peak
     /// observer, which fires on every video reconfigure, only reapplies on change.
@@ -57,7 +59,7 @@ final class MPVMetalViewController: UIViewController {
         setupMpv()
         
         if let url = playUrl {
-            loadFile(url)
+            loadFile(url, live: playUrlLive)
         }
     }
     
@@ -305,7 +307,8 @@ final class MPVMetalViewController: UIViewController {
     }
 
     func loadFile(
-        _ url: URL
+        _ url: URL,
+        live: Bool = false
     ) {
         var args = [url.absoluteString]
         var options = [String]()
@@ -321,8 +324,11 @@ final class MPVMetalViewController: UIViewController {
         // direct CDN keeps the full buffer for network resilience. Set per file at runtime.
         let isLocalStream = url.host == "127.0.0.1" || url.host == "localhost"
             || (url.host?.hasSuffix("strem.io") ?? false)
+        configureLiveMode(live)
         let readAhead: String
-        if PerformanceMode.reduced {
+        if live {
+            readAhead = "64MiB"
+        } else if PerformanceMode.reduced {
             readAhead = isLocalStream ? "64MiB" : "256MiB"   // 2 GB Apple TV HD: keep buffers tight
         } else {
             readAhead = isLocalStream ? "128MiB" : "512MiB"
@@ -335,6 +341,27 @@ final class MPVMetalViewController: UIViewController {
 
         mpvLog.log("loadFile → \(url.absoluteString, privacy: .public)")
         command("loadfile", args: args)
+    }
+
+    private func configureLiveMode(_ live: Bool) {
+        guard configuredLiveMode != live else { return }
+        configuredLiveMode = live
+        if live {
+            mpv_set_property_string(mpv, "demuxer-readahead-secs", "18")
+            mpv_set_property_string(mpv, "demuxer-max-back-bytes", "8MiB")
+            mpv_set_property_string(mpv, "demuxer-lavf-o", "live_start_index=-3")
+            // The VOD/debrid reconnect settings are hostile to HLS live: normal
+            // playlist/segment EOFs trigger ffmpeg's exponential "reconnect at 0"
+            // delay (1s, 3s, 7s), which is exactly the recurring live stall.
+            mpv_set_property_string(mpv, "stream-lavf-o",
+                                    "reconnect=1,reconnect_streamed=0,reconnect_delay_max=1")
+        } else {
+            mpv_set_property_string(mpv, "demuxer-readahead-secs", "300")
+            mpv_set_property_string(mpv, "demuxer-max-back-bytes", "64MiB")
+            mpv_set_property_string(mpv, "demuxer-lavf-o", "")
+            mpv_set_property_string(mpv, "stream-lavf-o",
+                                    "reconnect=1,reconnect_streamed=1,reconnect_delay_max=7")
+        }
     }
     
     func togglePause() {

--- a/app/Sources/Player/SkipTimestampService.swift
+++ b/app/Sources/Player/SkipTimestampService.swift
@@ -15,10 +15,7 @@ enum SkipTimestampService {
 
     static func candidates(imdbId: String, season: Int?, episode: Int?,
                            durationSeconds: Double) async -> [SegmentCandidate] {
-        guard let idItem = queryItem(for: imdbId) else {
-            log.info("unsupported id scheme: \(imdbId, privacy: .public)")
-            return []
-        }
+        guard let idItem = queryItem(for: imdbId) else { return [] }
         let key = "\(imdbId):\(season ?? 0):\(episode ?? 0)"
         if let cached = await SkipTimestampStore.shared.entry(for: key) {
             log.info("cache hit \(key, privacy: .public): \(cached.spans.count, privacy: .public) spans")
@@ -77,6 +74,10 @@ enum SkipTimestampService {
             return URLQueryItem(name: "tvdb_id", value: String(id))
         }
         return nil
+    }
+
+    static func supports(metaId: String) -> Bool {
+        queryItem(for: metaId) != nil
     }
 
     private static func candidates(from spans: [StoredSpan], duration: Double) -> [SegmentCandidate] {

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -95,6 +95,7 @@ struct TVPlayerView: View {
     // it loads in the background so Next/auto-advance still work.
     @State private var loadedEpisodes: [CoreVideo] = []
     @State private var curIsTorrent = false             // current stream is a torrent (switches/auto-next update it)
+    @State private var curIsLive = false                // current stream is live HLS/IPTV (switches/auto-next update it)
     @State private var torrentStatus: String?           // live warm-up line ("Connecting to peers · 12 connected")
     @State private var torrentWarmupsUsed = 0           // bounded warm-up rounds before the error overlay
     @State private var playSpeed = 1.0                  // mpv playback speed (sticky for the session)
@@ -125,6 +126,7 @@ struct TVPlayerView: View {
 
             MPVMetalPlayerView(coordinator: coordinator)
                 .play(url)
+                .live(initialLiveMode)
                 .onPropertyChange { _, name, data in
                     switch name {
                     case MPVProperty.pausedForCache: if let b = data as? Bool { buffering = b }
@@ -179,6 +181,7 @@ struct TVPlayerView: View {
                         loadTimeout?.cancel()
                         if !hasStartedPlaying { handleLoadFailure((data as? String) ?? "") }
                     case MPVProperty.endFileEof:
+                        if handleLiveStreamEOF() { break }
                         if !markedWatched, let m = curMeta { markedWatched = true; core.markPlaybackWatched(m) }
                         autoAdvance()                                // episode finished → play next, else exit
                     default: break
@@ -197,7 +200,7 @@ struct TVPlayerView: View {
                         Text(torrentStatus)
                             .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
                     } else if reconnecting {
-                        Text("Reconnecting…  (\(autoRetryCount)/\(maxAutoRetries))")
+                        Text(isCurrentLiveStream ? "Reconnecting live stream…" : "Reconnecting…  (\(autoRetryCount)/\(maxAutoRetries))")
                             .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
                     } else if sourceHops > 0, !hasStartedPlaying {
                         Text("Source failed, trying another…  (\(sourceHops)/\(maxSourceHops))")
@@ -216,7 +219,7 @@ struct TVPlayerView: View {
             }
         }
         .onAppear {
-            if curURL == nil { curURL = url; curTitle = title; curMeta = meta; curIsTorrent = torrent }   // seed from initial
+            if curURL == nil { curURL = url; curTitle = title; curMeta = meta; curIsTorrent = torrent; curIsLive = initialLiveMode }   // seed from initial
             if curHint == nil { curHint = sourceHint }
             if curBinge == nil { curBinge = bingeGroup }
             startStallWatchdog()
@@ -764,6 +767,7 @@ struct TVPlayerView: View {
         if userInitiated { closePanel() }
         curURL = newURL
         curIsTorrent = stream.isTorrent
+        curIsLive = isLiveMeta(curMeta) && !stream.isTorrent
         curBinge = stream.behaviorHints?.bingeGroup
         sourceHops = 0; exhaustedURLs = []   // a deliberate pick resets the failover budget (failover restores it)
         torrentWarmupsUsed = 0; torrentStatus = nil; stallRecoveries = 0
@@ -772,7 +776,7 @@ struct TVPlayerView: View {
         appliedResume = false
         buffering = true; hasStartedPlaying = false; appliedAutoTracks = false; loadErrorMsg = ""
         autoRetryCount = 0; reconnecting = false; autoRetryTask?.cancel()
-        coordinator.player?.loadFile(newURL)
+        coordinator.player?.loadFile(newURL, live: curIsLive)
         startLoadTimeout()
     }
 
@@ -1016,7 +1020,7 @@ struct TVPlayerView: View {
         resumeSeconds = currentTime
         appliedResume = false; appliedAutoTracks = false
         buffering = true
-        coordinator.player?.loadFile(curURL ?? url)
+        coordinator.player?.loadFile(curURL ?? url, live: isCurrentLiveStream)
     }
 
     private func startLoadTimeout() {
@@ -1137,6 +1141,10 @@ struct TVPlayerView: View {
             warmUpTorrent()
             return
         }
+        if isCurrentLiveStream {
+            scheduleLiveStreamReconnect(reason: "load failure: \(msg)")
+            return
+        }
         guard autoRetryCount < maxAutoRetries else {
             reconnecting = false
             if hopToNextSource(reason: "load failed: \(msg)") { return }
@@ -1161,8 +1169,40 @@ struct TVPlayerView: View {
         autoRetryTask?.cancel()
         withAnimation { loadFailed = false }
         buffering = true; hasStartedPlaying = false; appliedResume = false; appliedAutoTracks = false; loadErrorMsg = ""
-        coordinator.player?.loadFile(curURL ?? url)
+        coordinator.player?.loadFile(curURL ?? url, live: isCurrentLiveStream)
         startLoadTimeout()
+    }
+
+    /// Live HLS providers sometimes surface a transient playlist reload failure as EOF
+    /// instead of an mpv error. For VOD EOF means "finished"; for live streams it means
+    /// reconnect to the playlist rather than marking watched and closing the player.
+    private func handleLiveStreamEOF() -> Bool {
+        guard isCurrentLiveStream else { return false }
+        scheduleLiveStreamReconnect(reason: "EOF")
+        return true
+    }
+
+    private func scheduleLiveStreamReconnect(reason: String) {
+        buffering = true
+        withAnimation { reconnecting = true }
+        plog.info("live stream \(reason, privacy: .public), reconnecting")
+        DiagnosticsLog.log("player", "live stream \(reason), reconnecting")
+        autoRetryTask?.cancel()
+        autoRetryTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.5))
+            guard !Task.isCancelled else { return }
+            retryLoad(resetAutoRetries: false)
+        }
+    }
+
+    private var isCurrentLiveStream: Bool { curIsLive && !isTorrentPlayback }
+    private var initialLiveMode: Bool { !torrent && isLiveMeta(meta) }
+
+    /// Treat non-library ids (for example live sports ids) as live. Normal
+    /// scrobbleable/catalog ids keep the VOD buffering behavior.
+    private func isLiveMeta(_ meta: PlaybackMeta?) -> Bool {
+        guard let id = meta?.libraryId else { return false }
+        return !SkipTimestampService.supports(metaId: id)
     }
 
     // MARK: - Skip intro / outro (chapter-derived; AniSkip crowd-sourced timings can feed the same model later)
@@ -1189,6 +1229,13 @@ struct TVPlayerView: View {
     /// pill simply appears once the result lands, normally well before the intro is reached.
     private func fetchSkipTimestamps() {
         guard let m = curMeta else { plog.info("skip: no curMeta, not fetching"); return }
+        guard SkipTimestampService.supports(metaId: m.libraryId) else {
+            skipFetchTask?.cancel()
+            apiSkipCandidates = []
+            skipFetchKey = ""
+            refreshSkipSegments()
+            return
+        }
         let key = "\(m.libraryId):\(m.season ?? 0):\(m.episode ?? 0)"
         if key != skipFetchKey { apiSkipCandidates = [] }   // drop spans from the previous episode
         skipFetchKey = key
@@ -1277,6 +1324,7 @@ struct TVPlayerView: View {
             curHint = pre.signature
             curBinge = pre.bingeGroup
             curIsTorrent = pre.stream.isTorrent
+            curIsLive = isLiveMeta(newMeta) && !pre.stream.isTorrent
             torrentWarmupsUsed = 0; torrentStatus = nil
             stallRecoveries = 0
             plog.info("episode switch: playing preloaded best source")
@@ -1285,7 +1333,7 @@ struct TVPlayerView: View {
             Task {
                 core.loadMeta(type: "series", id: m.libraryId, streamType: "series", streamId: v.id)
                 resumeSeconds = await account.resumeOffset(for: newMeta)
-                coordinator.player?.loadFile(u)
+                coordinator.player?.loadFile(u, live: curIsLive)
                 startLoadTimeout()
                 // Hand the stream to the engine Player once its meta_details catches up, so
                 // Continue Watching keeps tracking; harmless if it never matches.
@@ -1321,8 +1369,9 @@ struct TVPlayerView: View {
                     core.loadEnginePlayer(for: s)
                     prepareTorrent(s)                                  // no-op for direct / debrid URLs
                     curURL = u
+                    curIsLive = isLiveMeta(newMeta) && !s.isTorrent
                     resumeSeconds = await account.resumeOffset(for: newMeta)
-                    coordinator.player?.loadFile(u)
+                    coordinator.player?.loadFile(u, live: curIsLive)
                     startLoadTimeout()
                     return
                 }


### PR DESCRIPTION
## What and why

Add support for playing live streams. Previously it would end the stream every time it got to the end of a segment (a few seconds in)

## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
