### PR TITLE
feat: add local trickplay capture and scrub thumbnails

### DIFF
--- a/app/Sources/Player/MPVMetalViewController.swift
+++ b/app/Sources/Player/MPVMetalViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -36,7 +37,10 @@ final class MPVMetalViewController: PlatformViewController {
     private var wakeupRelay: Unmanaged<WakeupRelay>?
     var playDelegate: MPVPlayerDelegate?
     lazy var queue = DispatchQueue(label: "mpv", qos: .userInitiated)
-    
+    private lazy var captureQueue = DispatchQueue(label: "com.stremiox.trickplay.capture", qos: .utility)
+    // Initialized on first capture using the same MTLDevice MPV renders into. Always accessed from
+    // captureQueue (serial), so no lock is needed.
+    private var ciContext: CIContext?
     var playUrl: URL?
     var playHeaders: [String: String]?
     var playUrlLive = false
@@ -56,7 +60,7 @@ final class MPVMetalViewController: PlatformViewController {
         super.viewDidLoad()
         
         metalLayer.frame = view.bounds
-        metalLayer.framebufferOnly = true
+        metalLayer.framebufferOnly = false  // must be false for CIImage(mtlTexture:) readback in captureFrameJPEGData
         // Insurance against render-thread/main-thread deadlocks: the drawable present must never wait
         // on the main run loop's CATransaction commit (presentsWithTransaction = false, the default —
         // made explicit), and nextDrawable() must be able to time out instead of blocking the vo thread
@@ -848,6 +852,37 @@ final class MPVMetalViewController: PlatformViewController {
         }
         if let cb = returnValueCallback {
             cb(returnValue)
+        }
+    }
+
+    func captureFrameJPEGData(completion: @escaping (Data?) -> Void) {
+        guard let drawable = metalLayer.captureDrawable else { completion(nil); return }
+        captureQueue.async { [self] in
+            let texture = drawable.texture
+            guard texture.width > 0, texture.height > 0 else { completion(nil); return }
+            // CIImage(mtlTexture:) handles any MTLPixelFormat natively; framebufferOnly=false
+            // (set in viewDidLoad) is required for the texture to be readable here.
+            guard let raw = CIImage(mtlTexture: texture,
+                                    options: [.colorSpace: CGColorSpaceCreateDeviceRGB()]) else {
+                NSLog("[trickplay] capture failed: CIImage(mtlTexture:) rejected fmt=%d", texture.pixelFormat.rawValue)
+                completion(nil)
+                return
+            }
+            // Metal (0,0) = top-left; CIImage (0,0) = bottom-left — combined flip+downscale
+            // transform: (x,y) → (x·s, (h−y)·s) where s = 480/textureWidth.
+            let s = 480 / CGFloat(texture.width)
+            let h = raw.extent.height
+            let image = raw.transformed(by: CGAffineTransform(a: s, b: 0, c: 0, d: -s, tx: 0, ty: h * s))
+            // CIContext holds GPU resources — create once, reuse across captures.
+            if ciContext == nil { ciContext = CIContext(mtlDevice: texture.device) }
+            guard let ctx = ciContext, let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
+                  let jpeg = ctx.jpegRepresentation(of: image, colorSpace: sRGB,
+                                                    options: [kCGImageDestinationLossyCompressionQuality as CIImageRepresentationOption: 0.7]) else {
+                NSLog("[trickplay] capture failed: JPEG encoding error")
+                completion(nil)
+                return
+            }
+            completion(jpeg)
         }
     }
 

--- a/app/Sources/Player/MetalLayer.swift
+++ b/app/Sources/Player/MetalLayer.swift
@@ -8,6 +8,28 @@ import AppKit
 
 class MetalLayer: CAMetalLayer {
 
+    // Tracks the last fully-presented drawable so captureFrameJPEGData can read its texture.
+    // MPV calls nextDrawable() to acquire a new render target; at that moment the previous target
+    // has been presented and is the frame the user sees. Written on MPV's render thread, read on
+    // the capture queue — protected by drawableLock.
+    private let drawableLock = NSLock()
+    private var _pendingDrawable: (any CAMetalDrawable)?
+    private var _displayedDrawable: (any CAMetalDrawable)?
+
+    var captureDrawable: (any CAMetalDrawable)? {
+        drawableLock.lock(); defer { drawableLock.unlock() }
+        return _displayedDrawable
+    }
+
+    override func nextDrawable() -> (any CAMetalDrawable)? {
+        let d = super.nextDrawable()
+        drawableLock.lock()
+        _displayedDrawable = _pendingDrawable
+        _pendingDrawable = d
+        drawableLock.unlock()
+        return d
+    }
+
     // workaround for a MoltenVK that sets the drawableSize to 1x1 to forcefully complete
     // the presentation, this causes flicker and the drawableSize possibly staying at 1x1
     // https://github.com/mpv-player/mpv/pull/13651

--- a/app/Sources/PlayerScreen.swift
+++ b/app/Sources/PlayerScreen.swift
@@ -117,6 +117,11 @@ struct PlayerScreen: View {
     ]
 
     @StateObject private var coordinator = MPVMetalPlayerView.Coordinator()
+    @StateObject private var scrubThumbnails = ScrubThumbnailsStore()
+    @State private var hoverPreviewTime: Double?
+    @State private var hoverPreviewRatio: CGFloat?
+    @State private var lastLocalTrickplayCapture = -1000.0
+    @State private var localTrickplayCaptureInFlight = false
     @AppStorage("stremiox.videoSize") private var videoSize = "original"   // whole frame, correct aspect
     @State private var appliedSize = false
     @State private var appliedInitialResume = false   // the launch-offset seek runs once; switches use nudgeResume
@@ -291,6 +296,7 @@ struct PlayerScreen: View {
         .tint(Theme.Palette.accent)
         .onAppear {
             curURL = url; curHeaders = headers; curIsTorrent = recordIsTorrent
+            scrubThumbnails.configure(localCacheKey: trickplayLocalCacheKey)
             scheduleHide(); startLoadTimeout()
             #if os(iOS)
             UIApplication.shared.isIdleTimerDisabled = true   // hold the screen awake while the player is open (parity with tvOS)
@@ -360,6 +366,7 @@ struct PlayerScreen: View {
                 if !scrubbing {
                     currentTime = d
                     updateCurrentSkip(at: d)
+                    maybeCaptureLocalTrickplay(at: d)
                     // Live streams must NOT write a resume offset: their "position" is just elapsed
                     // wall-clock of the buffer, and persisting it would make a later open seek into a
                     // bogus offset (or drop a fake Continue-Watching entry).
@@ -445,6 +452,65 @@ struct PlayerScreen: View {
 
     /// Persist the exact link that just started playing into LastStreamStore, so Continue-Watching can
     /// one-tap resume this stream and reopening the title auto-picks the same quality — the iOS/Mac twin
+    // MARK: - Local trickplay capture
+
+    private var trickplayLocalCacheKey: String {
+        if let m = recordMeta { return "v:\(m.libraryId):\(m.videoId)" }
+        return "u:\((curURL ?? url).absoluteString)"
+    }
+
+    private func maybeCaptureLocalTrickplay(at time: Double) {
+        guard !scrubbing, !buffering, !isPaused else { return }
+        guard !localTrickplayCaptureInFlight else { return }
+        guard time - lastLocalTrickplayCapture >= 10 else { return }
+        lastLocalTrickplayCapture = time
+        localTrickplayCaptureInFlight = true
+        coordinator.player?.captureFrameJPEGData { data in
+            self.localTrickplayCaptureInFlight = false
+            guard let data else { return }
+            self.scrubThumbnails.recordCapturedFrameData(data, at: time)
+        }
+    }
+
+    @ViewBuilder
+    private func trickplayPopup(time: Double) -> some View {
+        VStack(spacing: 4) {
+            if let image = scrubThumbnails.image {
+                #if canImport(AppKit)
+                let img = Image(nsImage: image)
+                #else
+                let img = Image(uiImage: image)
+                #endif
+                img.resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 320, height: 180)
+                    .background(.black)
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(.white.opacity(0.2), lineWidth: 1))
+            }
+            Text(timeString(time))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.white)
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(.black.opacity(0.75), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .shadow(color: .black.opacity(0.5), radius: 8, y: 4)
+    }
+
+    private func trickplayBubbleOffset(sliderWidth: CGFloat) -> CGFloat {
+        // When no thumbnail, the pill is narrow (~70 pt); use that for centering/clamping.
+        let popupWidth: CGFloat = scrubThumbnails.image != nil ? 320 : 70
+        guard sliderWidth > 0 else { return 0 }
+        let ratio: CGFloat
+        if let r = hoverPreviewRatio { ratio = r }
+        else if duration > 0 { ratio = CGFloat(scrubTarget / duration) }
+        else { return 0 }
+        return min(max(0, ratio * sliderWidth - popupWidth / 2), max(0, sliderWidth - popupWidth))
+    }
+
+    // MARK: - Continue Watching
+
     /// of TVPlayerView's record-on-start. Records the bare `curURL`/`curHeaders` the active source was
     /// launched with (a proxied loopback URL is rebuilt from these on resume), not the internal
     /// `initialPlayback` rewrite. No-op for ad-hoc plays with no `recordMeta` (e.g. paste-a-link).
@@ -981,21 +1047,59 @@ struct PlayerScreen: View {
             } else {
                 HStack(spacing: 12) {
                     Text(timeString(currentTime)).font(.caption.monospacedDigit()).foregroundStyle(.white)
-                    // While dragging, the thumb follows a local scrubTarget so an incoming timePos tick
-                    // can't yank it back to the (pre-seek) playback position (#32). On release we commit
-                    // scrubTarget once. Outside a drag the thumb tracks live currentTime.
-                    Slider(value: Binding(get: { scrubbing ? scrubTarget : currentTime },
-                                          set: { scrubTarget = $0 }),
-                           in: 0...max(duration, 1)) { editing in
-                        scrubbing = editing
-                        if editing { scrubTarget = currentTime; hideTask?.cancel() }
-                        else {
-                            currentTime = scrubTarget
-                            coordinator.player?.seek(to: scrubTarget)
-                            if duration > 0 { onSeek(scrubTarget, duration); lastReported = scrubTarget }
-                            scheduleHide()
+                    // Slider is wrapped in a GeometryReader so the trickplay bubble can be positioned
+                    // relative to the knob and macOS hover can compute the preview time from cursor x.
+                    GeometryReader { geo in
+                        // macOS Slider track is inset by ~half the thumb diameter on each side.
+                        let sliderInset: CGFloat = 10
+                        let trackWidth = max(1, geo.size.width - sliderInset * 2)
+                        // While dragging the thumb follows scrubTarget so an incoming timePos tick
+                        // can't yank it back to the pre-seek position (#32). On release we commit.
+                        Slider(value: Binding(get: { scrubbing ? scrubTarget : currentTime },
+                                              set: { scrubTarget = $0; scrubThumbnails.show(time: $0) }),
+                               in: 0...max(duration, 1)) { editing in
+                            scrubbing = editing
+                            if editing {
+                                scrubTarget = currentTime; hideTask?.cancel()
+                                hoverPreviewTime = nil; hoverPreviewRatio = nil
+                            } else {
+                                currentTime = scrubTarget
+                                coordinator.player?.seek(to: scrubTarget)
+                                if duration > 0 { onSeek(scrubTarget, duration); lastReported = scrubTarget }
+                                scrubThumbnails.clear()
+                                scheduleHide()
+                            }
                         }
-                    }.tint(Theme.Palette.accent)
+                        .tint(Theme.Palette.accent)
+                        #if os(macOS)
+                        .onContinuousHover { phase in
+                            switch phase {
+                            case .active(let loc):
+                                guard !scrubbing else { return }
+                                let ratio = min(max(0, (loc.x - sliderInset) / trackWidth), 1)
+                                hoverPreviewRatio = ratio
+                                hoverPreviewTime = ratio * max(duration, 0)
+                                scrubThumbnails.show(time: hoverPreviewTime!)
+                            case .ended:
+                                guard !scrubbing else { return }
+                                hoverPreviewTime = nil; hoverPreviewRatio = nil
+                                scrubThumbnails.clear()
+                            }
+                        }
+                        #endif
+                        // bottomLeading alignment: popup bottom anchors at slider bottom, grows upward.
+                        // y: -28 lifts it 4 pt above the slider top (slider is 24 pt tall).
+                        .overlay(alignment: .bottomLeading) {
+                            if scrubbing || hoverPreviewTime != nil {
+                                trickplayPopup(time: hoverPreviewTime ?? scrubTarget)
+                                    .fixedSize()
+                                    .offset(x: trickplayBubbleOffset(sliderWidth: geo.size.width), y: -28)
+                                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .bottom)))
+                            }
+                        }
+                    }
+                    .frame(height: 24)
+                    .animation(.easeOut(duration: 0.12), value: scrubThumbnails.image != nil)
                     Text(timeString(duration)).font(.caption.monospacedDigit()).foregroundStyle(.white)
                 }
             }

--- a/app/SourcesShared/ScrubThumbnails.swift
+++ b/app/SourcesShared/ScrubThumbnails.swift
@@ -1,0 +1,180 @@
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+#if canImport(AppKit)
+typealias ScrubImage = NSImage
+#elseif canImport(UIKit)
+typealias ScrubImage = UIImage
+#endif
+
+/// Provides scrub-preview thumbnails from locally captured frames.
+/// When no server storyboard is available the player captures a frame every ~10 s of playback
+/// and stores it via `recordCapturedFrameData`. During scrubbing `show(time:)` serves the
+/// nearest stored frame so the user gets a preview even without a network trickplay service.
+@MainActor
+final class ScrubThumbnailsStore: ObservableObject {
+    @Published private(set) var image: ScrubImage?
+
+    private var localCacheKey: String?
+    private static let localFrameCache = LocalTrickplayFrameCache()
+
+    func configure(localCacheKey: String?) {
+        guard self.localCacheKey != localCacheKey else { return }
+        self.localCacheKey = localCacheKey
+        image = nil
+    }
+
+    /// Shows the stored frame nearest to `time`. Call while the user is scrubbing.
+    func show(time: Double) {
+        guard let key = localCacheKey,
+              let local = Self.localFrameCache.image(for: key, time: time) else {
+            image = nil
+            return
+        }
+        image = local
+    }
+
+    func clear() {
+        image = nil
+    }
+
+    /// Stores a captured frame for future scrub previews.
+    func recordCapturedFrameData(_ data: Data, at time: Double) {
+        guard let key = localCacheKey, !key.isEmpty else { return }
+        guard let decoded = ScrubImage(data: data) else {
+            NSLog("[trickplay] dropping frame at %.0fs: JPEG decode failed", time)
+            return
+        }
+        #if canImport(AppKit)
+        if let cgImage = decoded.cgImage(forProposedRect: nil, context: nil, hints: nil),
+           Self.isBlackImage(cgImage) {
+            return
+        }
+        #endif
+        Self.localFrameCache.store(image: decoded, data: data, for: key, time: time)
+    }
+
+    /// Samples five points; considers the frame black (unrendered) if four or more are near-black.
+    #if canImport(AppKit)
+    private static func isBlackImage(_ cgImage: CGImage) -> Bool {
+        guard cgImage.width > 0, cgImage.height > 0 else { return true }
+        let w = cgImage.width, h = cgImage.height
+        guard let data = cgImage.dataProvider?.data else { return false }
+        let bytes = CFDataGetBytePtr(data)
+        let bpr = cgImage.bytesPerRow
+        let len = CFDataGetLength(data)
+        let points = [(w/4, h/4), (3*w/4, h/4), (w/2, h/2), (w/4, 3*h/4), (3*w/4, 3*h/4)]
+        let blackCount = points.filter { x, y in
+            let off = y * bpr + x * 4
+            guard off + 3 < len else { return false }
+            return (bytes?[off] ?? 0) < 30 && (bytes?[off+1] ?? 0) < 30 && (bytes?[off+2] ?? 0) < 30
+        }.count
+        return blackCount >= 4
+    }
+    #endif
+}
+
+// MARK: - Local frame cache
+
+private final class LocalTrickplayFrameCache {
+    private let bucketSeconds: Double = 2
+    private let maxLookbackBuckets = 180        // ~6 min back at 2 s per bucket
+    private let ttl: TimeInterval = 48 * 3600
+    private let maxDiskBytes: Int64 = 256 * 1024 * 1024
+    private let ioQueue = DispatchQueue(label: "com.stremiox.trickplay.localcache", qos: .utility)
+    private var memory: [String: [Int: ScrubImage]] = [:]
+    private var lastPrune = Date.distantPast
+
+    private lazy var cacheDirectory: URL = {
+        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let dir = base.appendingPathComponent("trickplay-local", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }()
+
+    init() {
+        ioQueue.async { _ = self.cacheDirectory }
+    }
+
+    func hasFrames(for key: String?) -> Bool {
+        guard let key, !key.isEmpty else { return false }
+        return ioQueue.sync {
+            if let buckets = memory[key], !buckets.isEmpty { return true }
+            let prefix = filePrefix(for: key) + "-"
+            let files = (try? FileManager.default.contentsOfDirectory(at: cacheDirectory, includingPropertiesForKeys: nil)) ?? []
+            return files.contains { $0.lastPathComponent.hasPrefix(prefix) }
+        }
+    }
+
+    func store(image: ScrubImage, data: Data, for key: String, time: Double) {
+        let bucket = bucketFor(time)
+        ioQueue.async {
+            self.memory[key, default: [:]][bucket] = image
+            try? data.write(to: self.fileURL(for: key, bucket: bucket), options: .atomic)
+            self.pruneIfNeeded()
+        }
+    }
+
+    func image(for key: String, time: Double) -> ScrubImage? {
+        let target = bucketFor(time)
+        return ioQueue.sync {
+            let minBucket = max(0, target - maxLookbackBuckets)
+            for bucket in stride(from: target, through: minBucket, by: -1) {
+                if let cached = memory[key]?[bucket] { return cached }
+                let url = fileURL(for: key, bucket: bucket)
+                guard let data = try? Data(contentsOf: url),
+                      let decoded = ScrubImage(data: data) else { continue }
+                memory[key, default: [:]][bucket] = decoded
+                return decoded
+            }
+            return nil
+        }
+    }
+
+    private func bucketFor(_ time: Double) -> Int { Int(max(0, floor(time / bucketSeconds))) }
+
+    private func fileURL(for key: String, bucket: Int) -> URL {
+        cacheDirectory.appendingPathComponent("\(filePrefix(for: key))-\(bucket).jpg")
+    }
+
+    private func filePrefix(for key: String) -> String {
+        Data(key.utf8).base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func pruneIfNeeded() {
+        let now = Date()
+        guard now.timeIntervalSince(lastPrune) > 600 else { return }
+        lastPrune = now
+        let keys: [URLResourceKey] = [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey]
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: cacheDirectory, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]
+        ) else { return }
+        var retained: [(url: URL, date: Date, size: Int64)] = []
+        var total: Int64 = 0
+        for file in files {
+            guard let vals = try? file.resourceValues(forKeys: Set(keys)),
+                  vals.isRegularFile == true else { continue }
+            let modified = vals.contentModificationDate ?? .distantPast
+            let size = Int64(vals.fileSize ?? 0)
+            if now.timeIntervalSince(modified) > ttl { try? FileManager.default.removeItem(at: file); continue }
+            total += size
+            retained.append((file, modified, size))
+        }
+        if total > maxDiskBytes {
+            for item in retained.sorted(by: { $0.date < $1.date }) {
+                if total <= maxDiskBytes { break }
+                try? FileManager.default.removeItem(at: item.url)
+                total -= item.size
+            }
+        }
+    }
+
+}

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -118,6 +118,9 @@ struct TVPlayerView: View {
     @State private var showStats = false                // live playback info overlay
     @State private var statsRows: [(String, String)] = []
     @State private var showStreamQR = false             // QR overlay sharing the playing link to a phone
+    @StateObject private var scrubThumbnails = ScrubThumbnailsStore()
+    @State private var lastLocalTrickplayCapture = -1000.0
+    @State private var localTrickplayCaptureInFlight = false
 
     /// Which on-screen control is currently highlighted (driven by remote left/right, not SwiftUI focus).
     private enum Control: Hashable { case close, scrub, restart, back, play, fwd, audio, subs, aspect, playback, prev, next, episodes, sources, settings }
@@ -170,6 +173,7 @@ struct TVPlayerView: View {
                             }
                             currentTime = d
                             updateCurrentSkip(at: d)
+                            maybeCaptureLocalTrickplay(at: d)
                             // Live: no progress is persisted (saveProgress no-ops) and nothing is reported
                             // to the engine — a live stream has no meaningful watch position.
                             if !isCurrentLiveStream, lastSaved < 0 || abs(d - lastSaved) >= 20 {   // persist ~every 20s
@@ -243,6 +247,7 @@ struct TVPlayerView: View {
                 curURL = url; curTitle = title; curMeta = meta
                 curIsTorrent = torrent; curHeaders = headers; curIsLive = initialLiveMode
             }
+            scrubThumbnails.configure(localCacheKey: trickplayLocalCacheKey)
             if curHint == nil { curHint = sourceHint }
             if curBinge == nil { curBinge = bingeGroup }
             startStallWatchdog()
@@ -519,13 +524,7 @@ struct TVPlayerView: View {
                     // control row is unreachable for live (see vertical()), so this stays presentation-only.
                     liveIndicator
                 } else {
-                    HStack(spacing: Theme.Space.md) {
-                        Text(timeString(scrubbing ? scrubTarget : currentTime)).font(.callout.monospacedDigit())
-                            .foregroundStyle(scrubbing ? Theme.Palette.accent : Theme.Palette.textPrimary)
-                        scrubber
-                        Text(timeString(duration)).font(.callout.monospacedDigit())
-                            .foregroundStyle(Theme.Palette.textSecondary)
-                    }
+                    trickplayControls
                 }
                 ZStack {
                     HStack(spacing: Theme.Space.md) {
@@ -882,6 +881,7 @@ struct TVPlayerView: View {
         curIsLive = isLiveMeta(curMeta) && !stream.isTorrent
         curBinge = stream.behaviorHints?.bingeGroup
         curHeaders = stream.requestHeaders
+        scrubThumbnails.configure(localCacheKey: trickplayLocalCacheKey)
         sourceHops = 0; exhaustedURLs = []   // a deliberate pick resets the failover budget (failover restores it)
         recoveryDeadline?.cancel(); recoveryDeadline = nil   // fresh attempt re-arms the overall recovery cap
         torrentWarmupsUsed = 0; torrentStatus = nil; stallRecoveries = 0
@@ -1530,6 +1530,7 @@ struct TVPlayerView: View {
             if let oldHash = leavingHash, oldHash != pre.stream.infoHash?.lowercased() { closeTorrent(hash: oldHash) }
             prepareTorrent(pre.stream)
             curURL = u
+            scrubThumbnails.configure(localCacheKey: trickplayLocalCacheKey)
             // @MainActor: the synchronous CoreBridge calls below (loadMeta / streamGroups ->
             // addonNamesByBase, which lazily mutates addonNamesCache) are main-actor-only. A bare
             // Task runs its pre-await body on a background thread, racing the dictionary against
@@ -1580,6 +1581,7 @@ struct TVPlayerView: View {
                     prepareTorrent(s)                                  // no-op for direct / debrid URLs
                     curURL = u
                     curIsLive = isLiveMeta(newMeta) && !s.isTorrent
+                    scrubThumbnails.configure(localCacheKey: trickplayLocalCacheKey)
                     resumeSeconds = await account.resumeOffset(for: newMeta)
                     loadIntoPlayer(u, headers: curHeaders, live: curIsLive)
                     startLoadTimeout()
@@ -1784,6 +1786,7 @@ struct TVPlayerView: View {
         }
         lastScrubAt = now
         scrubTarget = min(duration, max(0, scrubTarget + Double(dir) * scrubStep))
+        scrubThumbnails.show(time: scrubTarget)
         flashControls()
         scheduleScrubCommit()
     }
@@ -1803,11 +1806,83 @@ struct TVPlayerView: View {
         scrubbing = false
         coordinator.player?.seek(to: scrubTarget)
         currentTime = scrubTarget; lastSaved = scrubTarget
+        scrubThumbnails.clear()
         flashControls()
     }
     private func commitScrubIfNeeded() { if scrubbing { commitScrub() } }
     /// Discard the in-progress scrub preview and keep playing where we are (Menu while scrubbing).
-    private func cancelScrub() { scrubCommit?.cancel(); scrubbing = false; flashControls() }
+    private func cancelScrub() { scrubCommit?.cancel(); scrubbing = false; scrubThumbnails.clear(); flashControls() }
+
+    // MARK: - Local trickplay
+
+    private var trickplayLocalCacheKey: String {
+        if let m = curMeta { return "v:\(m.libraryId):\(m.videoId)" }
+        return "u:\((curURL ?? url).absoluteString)"
+    }
+
+    private func maybeCaptureLocalTrickplay(at time: Double) {
+        guard !scrubbing, !buffering, !isPaused else { return }
+        guard !localTrickplayCaptureInFlight else { return }
+        guard time - lastLocalTrickplayCapture >= 10 else { return }
+        lastLocalTrickplayCapture = time
+        localTrickplayCaptureInFlight = true
+        coordinator.player?.captureFrameJPEGData { data in
+            self.localTrickplayCaptureInFlight = false
+            guard let data else { return }
+            self.scrubThumbnails.recordCapturedFrameData(data, at: time)
+        }
+    }
+
+    /// Scrubber row that expands upward to show a trickplay bubble when the user is scrubbing.
+    private var trickplayControls: some View {
+        let shown = scrubbing ? scrubTarget : currentTime
+        let frac = duration > 0 ? min(1, max(0, shown / duration)) : 0
+        let sideWidth: CGFloat = 130
+        let spacing = Theme.Space.md
+        let bubbleWidth: CGFloat = 480
+        let bubbleHeight: CGFloat = 270
+        return GeometryReader { geo in
+            let scrubWidth = max(1, geo.size.width - sideWidth * 2 - spacing * 2)
+            let knobX = sideWidth + spacing + scrubWidth * frac
+            ZStack(alignment: .bottomLeading) {
+                if scrubbing, let image = scrubThumbnails.image {
+                    trickplayBubble(image, time: shown)
+                        .offset(x: min(max(0, knobX - bubbleWidth / 2), max(0, geo.size.width - bubbleWidth)), y: -42)
+                        .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .bottom)))
+                }
+                HStack(spacing: spacing) {
+                    Text(timeString(shown)).font(.callout.monospacedDigit())
+                        .foregroundStyle(scrubbing ? Theme.Palette.accent : Theme.Palette.textPrimary)
+                        .frame(width: sideWidth, alignment: .leading)
+                    scrubber
+                    Text(timeString(duration)).font(.callout.monospacedDigit())
+                        .foregroundStyle(Theme.Palette.textSecondary)
+                        .frame(width: sideWidth, alignment: .trailing)
+                }
+                .frame(maxHeight: .infinity, alignment: .bottom)
+            }
+            .animation(.easeOut(duration: 0.12), value: scrubThumbnails.image != nil)
+        }
+        .frame(height: scrubbing && scrubThumbnails.image != nil ? bubbleHeight + 26 : 28)
+    }
+
+    private func trickplayBubble(_ image: UIImage, time: Double) -> some View {
+        VStack(spacing: 6) {
+            Image(uiImage: image)
+                .resizable().aspectRatio(contentMode: .fit)
+                .frame(width: 480, height: 270)
+                .background(.black)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            Text(timeString(time))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(Theme.Palette.textPrimary)
+        }
+        .padding(6)
+        .background(.black.opacity(0.78), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .stroke(Theme.Palette.textPrimary.opacity(0.18), lineWidth: 1))
+        .shadow(color: .black.opacity(0.45), radius: 12, y: 6)
+    }
 
     /// Reveal the bar from a hidden state, selecting Play, and restart the auto-hide timer.
     private func showControls() {


### PR DESCRIPTION
## What and why

- Add local trickplay (thumbnail previews)
- It's an alternative/first step to #55 
- This version captures and caches screenshots locally to allow you to see previews as you go back to old previously watched content. The full version requires a server hosting all the trickplay thumbnails whereas this version doesn't.

## Screenshots

<img width="1256" height="808" alt="Screenshot 2026-06-14 at 21 58 00" src="https://github.com/user-attachments/assets/5da2fc4d-fe1d-4832-98f9-4e310210d18a" />


## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [x] Screenshots attached for UI changes
