### PR TITLE
fix(macos): search tab not opened when searching from home and improve suggestions

### DIFF
--- a/app/SourcesShared/CoreBridge.swift
+++ b/app/SourcesShared/CoreBridge.swift
@@ -1041,6 +1041,54 @@ final class CoreBridge: ObservableObject {
     }
 }
 
+// MARK: - Search suggestions
+
+extension CoreBridge {
+    /// Autocomplete titles for `.searchSuggestions`, shared between tvOS and iOS/macOS search.
+    ///
+    /// Priority order:
+    /// 1. Continue-watching titles that substring-match (personal, small, high signal).
+    /// 2. Engine suggestion catalog, interleaved movie/series (may be empty depending on addons).
+    /// 3. Current search results, interleaved by type (primary source when engine catalog is empty).
+    /// 4. Home board rows as a last-resort fallback.
+    ///
+    /// All sources are filtered to titles that contain `query` as a case/diacritic-insensitive
+    /// substring. The engine's suggestion API does fuzzy/related matching and can return unrelated
+    /// titles; the substring guard drops them client-side. Results are capped at 10.
+    func searchSuggestionTitles(for query: String) -> [String] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        var seen = Set<String>()
+        let opts: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+
+        func keep(_ title: String) -> Bool {
+            title.caseInsensitiveCompare(trimmed) != .orderedSame
+                && title.range(of: trimmed, options: opts) != nil
+                && seen.insert(title).inserted
+        }
+
+        func interleaved<T>(from items: [T], typeAt: KeyPath<T, String>, nameAt: KeyPath<T, String>) -> [String] {
+            let filtered = items.filter { keep($0[keyPath: nameAt]) }
+            let movies = filtered.filter { $0[keyPath: typeAt] == "movie" }
+            let series = filtered.filter { $0[keyPath: typeAt] == "series" }
+            let other  = filtered.filter { $0[keyPath: typeAt] != "movie" && $0[keyPath: typeAt] != "series" }
+            var mixed: [String] = []
+            for i in 0..<max(movies.count, series.count) {
+                if i < movies.count { mixed.append(movies[i][keyPath: nameAt]) }
+                if i < series.count { mixed.append(series[i][keyPath: nameAt]) }
+            }
+            return mixed + other.map { $0[keyPath: nameAt] }
+        }
+
+        let watching     = continueWatching.map(\.name).filter { keep($0) }
+        let engineMixed  = interleaved(from: searchSuggestions, typeAt: \.type, nameAt: \.name)
+        let resultsMixed = interleaved(from: searchResults,     typeAt: \.type, nameAt: \.name)
+        let board        = boardRows.flatMap(\.items).filter { keep($0.name) }.map(\.name)
+
+        return Array((watching + engineMixed + resultsMixed + board).prefix(10))
+    }
+}
+
 /// Top-level C callback (no captures allowed). `ctx` is deliberately unused: resolving the
 /// process-lifetime singleton directly is always safe, while dereferencing an unretained
 /// pointer from a Rust worker thread would be a use-after-free if the bridge were ever

--- a/app/SourcesTV/SearchView.swift
+++ b/app/SourcesTV/SearchView.swift
@@ -119,47 +119,7 @@ struct SearchView: View {
         query.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
     }
 
-    private var suggestionTitles: [String] {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-        var seen = Set<String>()
-        let opts: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
-
-        // Returns true (and records the title) only if it contains the query as a substring
-        // and hasn't been seen before. Exact matches are excluded (the user typed it already).
-        func keep(_ title: String) -> Bool {
-            title.caseInsensitiveCompare(trimmed) != .orderedSame
-                && title.range(of: trimmed, options: opts) != nil
-                && seen.insert(title).inserted
-        }
-
-        // Continue watching first: small, personal, high signal.
-        let watching = core.continueWatching.map(\.name).filter { keep($0) }
-
-        // Engine suggestion catalog — interleaved by type when available. In practice this may
-        // be empty if the addon set doesn't provide a suggestion catalog, in which case
-        // searchResults below becomes the effective source.
-        func interleaved<T>(from items: [T], typeAt: KeyPath<T, String>, nameAt: KeyPath<T, String>) -> [String] {
-            let filtered = items.filter { keep($0[keyPath: nameAt]) }
-            let movies = filtered.filter { $0[keyPath: typeAt] == "movie" }
-            let series = filtered.filter { $0[keyPath: typeAt] == "series" }
-            let other  = filtered.filter { $0[keyPath: typeAt] != "movie" && $0[keyPath: typeAt] != "series" }
-            var mixed: [String] = []
-            for i in 0..<max(movies.count, series.count) {
-                if i < movies.count { mixed.append(movies[i][keyPath: nameAt]) }
-                if i < series.count { mixed.append(series[i][keyPath: nameAt]) }
-            }
-            return mixed + other.map { $0[keyPath: nameAt] }
-        }
-
-        let engineMixed = interleaved(from: core.searchSuggestions, typeAt: \.type, nameAt: \.name)
-        // searchResults carry full type info — apply the same interleaving so series from the
-        // current results aren't pushed behind all movies (the root cause of GoT appearing late).
-        let resultsMixed = interleaved(from: core.searchResults, typeAt: \.type, nameAt: \.name)
-        let board = core.boardRows.flatMap { $0.items }.filter { keep($0.name) }.map(\.name)
-
-        return Array((watching + engineMixed + resultsMixed + board).prefix(10))
-    }
+    private var suggestionTitles: [String] { core.searchSuggestionTitles(for: query) }
 
     private func scheduleSearch(_ value: String) {
         searchTask?.cancel()

--- a/app/SourcesiOS/iOSRootView.swift
+++ b/app/SourcesiOS/iOSRootView.swift
@@ -525,6 +525,11 @@ struct iOSSearchView: View {
                 searchDebouncePending = false
                 core.suggestSearch(query)
                 core.search(query)
+                // On macOS the search bar is visible in the toolbar on every tab (all tabs stay
+                // mounted). Switch to the Search tab so results are actually visible.
+                #if os(macOS)
+                if !isActive { MacCommands.go(.search) }
+                #endif
             }
             .onAppear { core.loadSearchSuggestions() }
             .onChange(of: query) { value in scheduleSearch(value) }   // iOS 16 single-param onChange

--- a/app/SourcesiOS/iOSRootView.swift
+++ b/app/SourcesiOS/iOSRootView.swift
@@ -591,29 +591,7 @@ struct iOSSearchView: View {
         return [("Movies", movies), ("Series", series), ("Other", other)].filter { !$0.items.isEmpty }
     }
 
-    /// Autocomplete titles for `.searchSuggestions`, from the engine's LocalSearch index plus any
-    /// loaded result / Continue-Watching / board titles that substring-match — the tvOS approach.
-    private var suggestionTitles: [String] {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-        var seen = Set<String>()
-
-        let coreSuggestions = core.searchSuggestions.map(\.name).filter { title in
-            guard title.caseInsensitiveCompare(trimmed) != .orderedSame else { return false }
-            return seen.insert(title).inserted
-        }
-        let localTitles = core.searchResults.map(\.name)
-            + core.continueWatching.map(\.name)
-            + core.boardRows.flatMap { $0.items.map(\.name) }
-        let localMatches = localTitles.filter { title in
-            guard title.caseInsensitiveCompare(trimmed) != .orderedSame else { return false }
-            guard title.range(of: trimmed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
-                return false
-            }
-            return seen.insert(title).inserted
-        }
-        return Array((coreSuggestions + localMatches).prefix(10))
-    }
+    private var suggestionTitles: [String] { core.searchSuggestionTitles(for: query) }
 
     private var hasSearchQuery: Bool {
         query.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2


### PR DESCRIPTION
## What and why

Closes #80 

- fix(macos): search tab not opened when searching from home
- feat(macos,ios): share same smart search suggestions from tvOS across apps

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
