### PR TITLE
feat: Add support for a more like this section

### DIFF
--- a/app/SourcesShared/Addon.swift
+++ b/app/SourcesShared/Addon.swift
@@ -9,6 +9,7 @@ struct MetaPreview: Identifiable, Decodable, Hashable {
     let name: String
     let poster: String?
     let posterShape: String?
+    let popularity: Double?
 }
 
 /// Full meta (detail page). `videos` is present for series (episodes).
@@ -119,6 +120,68 @@ struct AddonClient {
     func catalog(base: String, type: String, id: String, genre: String) async throws -> [MetaPreview] {
         let g = genre.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? genre
         return try await Self.get("\(base)/catalog/\(type)/\(id)/genre=\(g).json", as: MetasResponse.self).metas
+    }
+
+    /// Fetches items similar to a given title. Runs genre-filtered top catalogs (up to 3 genres)
+    /// and, when the title looks like a series member (subtitle after a colon, or trailing number),
+    /// a keyword search for the series name — all in parallel. Results are merged, deduplicated,
+    /// and sorted by an effective popularity that gives franchise keyword matches a 3× boost so
+    /// related entries in the same series surface above equally-popular genre-only results.
+    /// In the future, if we add a TMDB API key or similar, we could use the Recommendations API.
+    static func similar(type: String, excludingId: String, genres: [String], title: String) async -> [MetaPreview] {
+        let genresToQuery = Array(genres.prefix(3))
+        guard !genresToQuery.isEmpty else { return [] }
+        let keyword = franchiseKeyword(from: title)
+        return await withTaskGroup(of: (isKeyword: Bool, items: [MetaPreview]).self) { group in
+            for genre in genresToQuery {
+                group.addTask {
+                    let g = genre.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? genre
+                    let items = (try? await get("\(cinemeta)/catalog/\(type)/top/genre=\(g).json",
+                                               as: MetasResponse.self))?.metas ?? []
+                    return (false, items)
+                }
+            }
+            if let kw = keyword {
+                group.addTask {
+                    let q = kw.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? kw
+                    let items = (try? await get("\(cinemeta)/catalog/\(type)/top/search=\(q).json",
+                                               as: MetasResponse.self))?.metas ?? []
+                    return (true, items)
+                }
+            }
+            var byId: [String: MetaPreview] = [:]
+            var keywordIds = Set<String>()
+            for await (isKeyword, items) in group {
+                for item in items where item.id != excludingId {
+                    byId[item.id] = item
+                    if isKeyword { keywordIds.insert(item.id) }
+                }
+            }
+            // Keyword (series) matches get a 3× popularity boost so they rank above genre-only
+            // results of similar raw popularity. Items with no popularity fall back to 0.
+            let results = byId.values.sorted {
+                let aScore = ($0.popularity ?? 0) * (keywordIds.contains($0.id) ? 3 : 1)
+                let bScore = ($1.popularity ?? 0) * (keywordIds.contains($1.id) ? 3 : 1)
+                return aScore > bScore
+            }
+            return results
+        }
+    }
+
+    /// Extracts a series keyword from a title when the title signals it belongs to a series:
+    /// anything before a colon (e.g. "Title: Subtitle" → "Title"), or the base name with a
+    /// trailing Arabic number stripped (e.g. "Title 3" → "Title"). Returns nil for standalone
+    /// titles where a keyword search would just return the same item.
+    private static func franchiseKeyword(from title: String) -> String? {
+        if let colonRange = title.range(of: ":") {
+            let before = title[..<colonRange.lowerBound].trimmingCharacters(in: .whitespaces)
+            if !before.isEmpty { return before }
+        }
+        let words = title.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        if let last = words.last, Int(last) != nil, words.count > 1 {
+            return words.dropLast().joined(separator: " ")
+        }
+        return nil
     }
 
     func search(type: String, query: String) async throws -> [MetaPreview] {

--- a/app/SourcesTV/DetailView.swift
+++ b/app/SourcesTV/DetailView.swift
@@ -12,6 +12,8 @@ struct DetailView: View {
     @EnvironmentObject private var profiles: ProfileStore
     @EnvironmentObject private var presenter: PlayerPresenter   // root-replacement player presentation (Trailer)
 
+    @State private var similarItems: [MetaPreview] = []
+
     var body: some View {
         Group {
             if let meta = core.metaDetails?.meta {
@@ -54,10 +56,12 @@ struct DetailView: View {
                 core.loadMeta(type: type, id: id)
             }
             captureHero()
+            if let m = core.metaDetails?.meta, m.id == id { loadSimilar(m) }
         }
         .onChange(of: core.metaDetails?.meta?.id) {
             captureHero()
             if type != "series" { loadMovieStreamsIfNeeded() }
+            if let m = core.metaDetails?.meta, m.id == id { loadSimilar(m) }
         }
     }
 
@@ -79,6 +83,32 @@ struct DetailView: View {
         let hasStreams = core.metaDetails?.streams.contains { $0.request.path.id == streamId } ?? false
         guard !hasStreams else { return }
         core.loadMeta(type: type, id: id, streamType: type, streamId: streamId)
+    }
+
+    @ViewBuilder private var moreLikeThisSection: some View {
+        if !similarItems.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Space.md) {
+                RailHeader(title: "More Like This")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(alignment: .top, spacing: Theme.Space.lg) {
+                        ForEach(similarItems.prefix(20)) { item in
+                            PosterCard(title: item.name, poster: item.poster,
+                                       type: item.type, id: item.id)
+                        }
+                    }
+                    .padding(.horizontal, Theme.Space.screenEdge)
+                    .padding(.vertical, Theme.Space.lg)
+                }
+            }
+        }
+    }
+
+    private func loadSimilar(_ meta: CoreMetaItem) {
+        guard !LiveTypes.contains(type), !meta.genres.isEmpty else { return }
+        Task {
+            let items = await AddonClient.similar(type: type, excludingId: id, genres: meta.genres, title: meta.name)
+            await MainActor.run { similarItems = items }
+        }
     }
 
     /// Feed the browse pages' hero cache with what this page knows. The engine resolved this meta
@@ -108,6 +138,7 @@ struct DetailView: View {
                                          watched: watched,
                                          initialSeason: primary?.video.season)
                         .id("detailContent")
+                    moreLikeThisSection
                 }
                 .padding(.bottom, Theme.Space.xl)
             }
@@ -122,30 +153,33 @@ struct DetailView: View {
             FullBleedBackdrop(url: m.background ?? m.poster)
             ScrollView {
                 VStack(alignment: .leading, spacing: Theme.Space.lg) {
-                    Spacer().frame(height: 380)
-                    VStack(alignment: .leading, spacing: Theme.Space.sm) {
-                        Text(m.name)
-                            .font(Theme.Typography.hero).tracking(-1.5)
-                            .foregroundStyle(Theme.Palette.textPrimary)
-                            .lineLimit(2).minimumScaleFactor(0.6)
-                            .shadow(color: .black.opacity(0.5), radius: 12, y: 4)
-                        metaRow(m)
-                        if let d = m.description, !d.isEmpty {
-                            Text(d)
-                                .font(Theme.Typography.body)
-                                .foregroundStyle(Theme.Palette.textSecondary)
-                                .lineLimit(4).lineSpacing(2)
-                                .frame(maxWidth: 1000, alignment: .leading)
+                    VStack(alignment: .leading, spacing: Theme.Space.lg) {
+                        Spacer().frame(height: 380)
+                        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+                            Text(m.name)
+                                .font(Theme.Typography.hero).tracking(-1.5)
+                                .foregroundStyle(Theme.Palette.textPrimary)
+                                .lineLimit(2).minimumScaleFactor(0.6)
+                                .shadow(color: .black.opacity(0.5), radius: 12, y: 4)
+                            metaRow(m)
+                            if let d = m.description, !d.isEmpty {
+                                Text(d)
+                                    .font(Theme.Typography.body)
+                                    .foregroundStyle(Theme.Palette.textSecondary)
+                                    .lineLimit(4).lineSpacing(2)
+                                    .frame(maxWidth: 1000, alignment: .leading)
+                            }
+                            HStack(spacing: Theme.Space.sm) { trailerChip(m) }
+                                .padding(.top, Theme.Space.xs)
                         }
-                        HStack(spacing: Theme.Space.sm) { trailerChip(m) }
-                            .padding(.top, Theme.Space.xs)
+                        CoreStreamList(title: m.name,
+                                       meta: PlaybackMeta(libraryId: m.id, videoId: m.id, type: type,
+                                                          name: m.name, poster: m.poster,
+                                                          season: nil, episode: nil))
                     }
-                    CoreStreamList(title: m.name,
-                                   meta: PlaybackMeta(libraryId: m.id, videoId: m.id, type: type,
-                                                      name: m.name, poster: m.poster,
-                                                      season: nil, episode: nil))
+                    .padding(.horizontal, Theme.Space.screenEdge)
+                    moreLikeThisSection
                 }
-                .padding(.horizontal, Theme.Space.screenEdge)
                 .padding(.bottom, Theme.Space.xl)
             }
         }

--- a/app/SourcesiOS/iOSDetailView.swift
+++ b/app/SourcesiOS/iOSDetailView.swift
@@ -164,6 +164,7 @@ struct iOSDetailView: View {
     @State private var season = 1
     @State private var settleTimedOut = false            // movie/live resolution gave up → "No sources found", not a spinner
     @State private var torrentPrime: Task<Void, Never>?  // outstanding torrent /create retry loop, cancelled on disappear / new pick
+    @State private var similarItems: [MetaPreview] = []
 
     /// The one thing presented full-screen at a time: a resolved player stream or the YouTube trailer.
     private enum Presentation: Identifiable {
@@ -244,6 +245,7 @@ struct iOSDetailView: View {
                             }
                             .frame(maxWidth: geo.size.width > 700 ? 900 : .infinity)
                             .frame(maxWidth: .infinity)
+                            moreLikeThisSection
                         }
                     }
                     .padding(.bottom, Theme.Space.xl)
@@ -265,6 +267,7 @@ struct iOSDetailView: View {
             } else {
                 core.loadMeta(type: type, id: id) // load meta FIRST; onChange dispatches streams on arrival
             }
+            if let m = core.metaDetails?.meta, m.id == id { loadSimilar(m) }
         }
         // A movie/live title is a SINGLE video, but its stream request must carry the IMDB id, not the raw
         // catalog id: a TMDB/Kitsu catalog gives the meta a tmdb:/kitsu: id, and imdb-keyed stream add-ons
@@ -278,6 +281,7 @@ struct iOSDetailView: View {
                 // first time; on by default). Keyed by series id, so revisiting refreshes rather than dupes.
                 Task { await NewEpisodeNotifications.scheduleUpcomingAuthorized(seriesId: m.id, seriesName: m.name, videos: videos) }
             }
+            if let m = meta { loadSimilar(m) }
         }
         // Do NOT unloadMeta here. On iOS, pushing the per-episode page (iOSEpisodeStreams) fires THIS
         // detail page's onDisappear AFTER the episode page has already loaded its streams — so calling
@@ -1089,6 +1093,53 @@ struct iOSDetailView: View {
     }
 
     private func seasonLabel(_ s: Int) -> String { s == 0 ? "Specials" : "Season \(s)" }
+
+    // MARK: More Like This
+
+    @ViewBuilder private var moreLikeThisSection: some View {
+        if !similarItems.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Space.sm) {
+                iOSRailHeader(eyebrow: type == "series" ? "Similar Series" : "Similar Movies",
+                              title: "More Like This")
+                    .padding(.horizontal, Theme.Space.md)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Theme.Space.sm) {
+                        ForEach(similarItems.prefix(20)) { item in
+                            NavigationLink {
+                                iOSDetailView(id: item.id, type: item.type, title: item.name)
+                            } label: {
+                                moreLikeThisCard(item)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, Theme.Space.md)
+                }
+            }
+        }
+    }
+
+    private func moreLikeThisCard(_ item: MetaPreview) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            CachedPosterImage(url: item.poster)
+                .frame(width: 100, height: 150)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+            Text(item.name)
+                .font(Theme.Typography.label)
+                .foregroundStyle(Theme.Palette.textSecondary)
+                .lineLimit(1)
+                .frame(width: 100, alignment: .leading)
+        }
+    }
+
+    private func loadSimilar(_ meta: CoreMetaItem) {
+        guard !LiveTypes.contains(type), !meta.genres.isEmpty else { return }
+        Task {
+            let items = await AddonClient.similar(type: type, excludingId: id, genres: meta.genres, title: meta.name)
+            await MainActor.run { similarItems = items }
+        }
+    }
 
     // MARK: Shared
 


### PR DESCRIPTION


## What and why
Add support for a more like this section

- it makes a best guess at recommendations from Cinemeta mostly using genres
- worse case, it just shows you some other top films from the same genre which means the recommendations will be similar if you keep looking at "Action" films

It does a reasonable job at getting recommendations, but if we ever added TMDB support then it could probably use that API first if the user provides a key. They have both Recommendations and Similar APIs, but I've found the Similar one can return some very random results.

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

<img width="585" height="543" alt="image" src="https://github.com/user-attachments/assets/bafea1d8-964a-4da9-8b52-3cfe6a66565e" />


## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [x] Screenshots attached for UI changes
