### PR TITLE
fix(tvos): Restore nav/tab bar after returning from detail view

### DIFF
--- a/app/SourcesTV/DetailView.swift
+++ b/app/SourcesTV/DetailView.swift
@@ -55,6 +55,12 @@ struct DetailView: View {
             }
             captureHero()
         }
+        .onDisappear {
+            // Scrolling the series episode list auto-hides the tab bar at the UIKit level. When the
+            // user presses Back the NavigationStack pops but the bar can stay hidden at its scroll-
+            // suppressed position. Heal it the same way the player-close path does.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { TabBarHealer.heal("detail-popped") }
+        }
         .onChange(of: core.metaDetails?.meta?.id) {
             captureHero()
             if type != "series" { loadMovieStreamsIfNeeded() }


### PR DESCRIPTION
Closes #75

## What and why

- Restore nav/tab bar after returning from detail view

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
