### PR TITLE
fix(macos): stop crash caused by trickplay when in background

### DIFF
--- a/app/Sources/Player/MPVMetalViewController.swift
+++ b/app/Sources/Player/MPVMetalViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Metal
+import ImageIO
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -38,9 +39,13 @@ final class MPVMetalViewController: PlatformViewController {
     var playDelegate: MPVPlayerDelegate?
     lazy var queue = DispatchQueue(label: "mpv", qos: .userInitiated)
     private lazy var captureQueue = DispatchQueue(label: "com.stremiox.trickplay.capture", qos: .utility)
-    // Initialized on first capture using the same MTLDevice MPV renders into. Always accessed from
+    // Initialized on first capture using the same MTLDevice mpv renders into. Always accessed from
     // captureQueue (serial), so no lock is needed.
     private var ciContext: CIContext?
+    // Tracks the last drawable size and format for which captureTexture was created, so that
+    // updateCapturePipeline() is a no-op when called from captureFrameJPEGData every 10 s.
+    private var capturePipelineSize: CGSize = .zero
+    private var capturePipelineFormat: MTLPixelFormat = .invalid
     var playUrl: URL?
     var playHeaders: [String: String]?
     var playUrlLive = false
@@ -62,7 +67,7 @@ final class MPVMetalViewController: PlatformViewController {
         super.viewDidLoad()
         
         metalLayer.frame = view.bounds
-        metalLayer.framebufferOnly = false  // must be false for CIImage(mtlTexture:) readback in captureFrameJPEGData
+        metalLayer.framebufferOnly = false  // must be false for MoltenVK internal blits (e.g. format resolve)
         // Insurance against render-thread/main-thread deadlocks: the drawable present must never wait
         // on the main run loop's CATransaction commit (presentsWithTransaction = false, the default —
         // made explicit), and nextDrawable() must be able to time out instead of blocking the vo thread
@@ -605,11 +610,26 @@ final class MPVMetalViewController: PlatformViewController {
         getFlag(MPVProperty.pause) ? play() : pause()
     }
 
-    /// Match the output chain to the playing file's dynamic range: mpv encodes
-    /// PQ or HLG instead of tone-mapping to SDR, the Metal layer gets the matching
-    /// colorspace tag, and on tvOS the TV is asked to switch into HDR mode (which
-    /// is what lights the TV's HDR badge). Runs on the main thread from the
-    /// sig-peak observer, once per video reconfigure.
+    private func updateCapturePipeline() {
+        guard let device = metalLayer.device else { return }
+        let size = metalLayer.drawableSize
+        let fmt = metalLayer.pixelFormat
+        guard size.width > 1, size.height > 1 else { return }
+        guard size != capturePipelineSize || fmt != capturePipelineFormat else { return }
+
+        guard let queue = device.makeCommandQueue() else { return }
+        metalLayer.setupCaptureQueue(queue)
+
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: fmt, width: Int(size.width), height: Int(size.height), mipmapped: false)
+        desc.usage = .shaderRead
+        desc.storageMode = .shared
+        guard let tex = device.makeTexture(descriptor: desc) else { return }
+        metalLayer.updateCaptureTexture(tex)
+        capturePipelineSize = size
+        capturePipelineFormat = fmt
+    }
+
     /// Re-derive the dynamic range from the CURRENTLY decoded video params and apply it. Used by the
     /// gamma observer and MPV_EVENT_VIDEO_RECONFIG, neither of which carries a sig-peak value, so it
     /// reads sig-peak fresh. Unlike the sig-peak property-change observer this does NOT depend on a value
@@ -952,33 +972,37 @@ final class MPVMetalViewController: PlatformViewController {
     }
 
     func captureFrameJPEGData(completion: @escaping (Data?) -> Void) {
-        guard let drawable = metalLayer.captureDrawable else { completion(nil); return }
-        captureQueue.async { [self] in
-            let texture = drawable.texture
-            guard texture.width > 0, texture.height > 0 else { completion(nil); return }
-            // CIImage(mtlTexture:) handles any MTLPixelFormat natively; framebufferOnly=false
-            // (set in viewDidLoad) is required for the texture to be readable here.
-            guard let raw = CIImage(mtlTexture: texture,
-                                    options: [.colorSpace: CGColorSpaceCreateDeviceRGB()]) else {
-                NSLog("[trickplay] capture failed: CIImage(mtlTexture:) rejected fmt=%d", texture.pixelFormat.rawValue)
-                completion(nil)
-                return
+        guard mpv != nil else { completion(nil); return }
+        // Build or rebuild the pipeline lazily — at VIDEO_RECONFIG time the device/drawableSize may
+        // not be set yet (especially on tvOS); calling here retries until everything is ready.
+        // updateCapturePipeline is a no-op once the pipeline matches the current resolution/format.
+        updateCapturePipeline()
+        // requestCapture schedules a blit for the next nextDrawable() call on mpv's VO thread.
+        // handler(nil) is called immediately by MetalLayer if the blit cannot be submitted, so
+        // the caller's in-flight guard is always released even when the pipeline isn't ready yet.
+        metalLayer.requestCapture { [weak self] texture in
+            guard let self, let texture else { completion(nil); return }
+            self.captureQueue.async {
+                // CIImage(mtlTexture:) wraps the texture lazily. Metal textures have (0,0) at
+                // top-left; CIImage has (0,0) at bottom-left — flip y while scaling to 480px wide.
+                guard let raw = CIImage(mtlTexture: texture,
+                                        options: [.colorSpace: CGColorSpaceCreateDeviceRGB()]) else {
+                    completion(nil); return
+                }
+                let tw = CGFloat(texture.width), th = CGFloat(texture.height)
+                let s = 480.0 / tw
+                let image = raw.transformed(by: CGAffineTransform(a: s, b: 0, c: 0, d: -s, tx: 0, ty: th * s))
+                if self.ciContext == nil { self.ciContext = CIContext(mtlDevice: texture.device) }
+                guard let ctx = self.ciContext,
+                      let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
+                      let jpeg = ctx.jpegRepresentation(
+                          of: image, colorSpace: sRGB,
+                          options: [kCGImageDestinationLossyCompressionQuality as CIImageRepresentationOption: 0.7]
+                      ) else {
+                    completion(nil); return
+                }
+                completion(jpeg)
             }
-            // Metal (0,0) = top-left; CIImage (0,0) = bottom-left — combined flip+downscale
-            // transform: (x,y) → (x·s, (h−y)·s) where s = 480/textureWidth.
-            let s = 480 / CGFloat(texture.width)
-            let h = raw.extent.height
-            let image = raw.transformed(by: CGAffineTransform(a: s, b: 0, c: 0, d: -s, tx: 0, ty: h * s))
-            // CIContext holds GPU resources — create once, reuse across captures.
-            if ciContext == nil { ciContext = CIContext(mtlDevice: texture.device) }
-            guard let ctx = ciContext, let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
-                  let jpeg = ctx.jpegRepresentation(of: image, colorSpace: sRGB,
-                                                    options: [kCGImageDestinationLossyCompressionQuality as CIImageRepresentationOption: 0.7]) else {
-                NSLog("[trickplay] capture failed: JPEG encoding error")
-                completion(nil)
-                return
-            }
-            completion(jpeg)
         }
     }
 
@@ -1091,6 +1115,7 @@ final class MPVMetalViewController: PlatformViewController {
                     DispatchQueue.main.async { [weak self] in
                         guard let self, self.mpv != nil else { return }
                         self.reapplyDynamicRange()
+                        self.updateCapturePipeline()
                     }
                 case MPV_EVENT_END_FILE:
                     // A file finished, if it ENDED IN ERROR (couldn't open: dead/uncached link,

--- a/app/Sources/Player/MetalLayer.swift
+++ b/app/Sources/Player/MetalLayer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 import QuartzCore
 #if canImport(UIKit)
 import UIKit
@@ -8,25 +9,75 @@ import AppKit
 
 class MetalLayer: CAMetalLayer {
 
-    // Tracks the last fully-presented drawable so captureFrameJPEGData can read its texture.
-    // MPV calls nextDrawable() to acquire a new render target; at that moment the previous target
-    // has been presented and is the frame the user sees. Written on MPV's render thread, read on
-    // the capture queue — protected by drawableLock.
-    private let drawableLock = NSLock()
-    private var _pendingDrawable: (any CAMetalDrawable)?
-    private var _displayedDrawable: (any CAMetalDrawable)?
+    // Trickplay capture: when a capture is requested, the next nextDrawable() call blits the
+    // newly acquired drawable's texture into captureTexture before returning the drawable to mpv.
+    // The newly acquired drawable holds the frame from 2+ renders ago — valid and not in transition,
+    // unlike the previous drawable which MoltenVK may recycle inside super.nextDrawable().
+    // All fields protected by captureLock (VO thread vs main thread).
+    private let captureLock = NSLock()
+    private var captureCommandQueue: MTLCommandQueue?
+    private var captureTexture: MTLTexture?
+    // Handler receives the texture on success, or nil if the blit could not be submitted
+    // (pipeline not ready, size mismatch). Caller MUST handle nil to unblock its in-flight guard.
+    private var _captureHandler: ((MTLTexture?) -> Void)?
 
-    var captureDrawable: (any CAMetalDrawable)? {
-        drawableLock.lock(); defer { drawableLock.unlock() }
-        return _displayedDrawable
+    func setupCaptureQueue(_ queue: MTLCommandQueue) {
+        captureLock.lock()
+        captureCommandQueue = queue
+        captureLock.unlock()
+    }
+
+    func updateCaptureTexture(_ texture: MTLTexture?) {
+        captureLock.lock()
+        captureTexture = texture
+        captureLock.unlock()
+    }
+
+    /// Schedule a single frame capture. handler(texture) fires on a Metal completion thread when
+    /// the GPU blit finishes, or handler(nil) fires immediately if the blit cannot be submitted.
+    /// Replaces any pending unserviced handler (best-effort, no backlog).
+    func requestCapture(handler: @escaping (MTLTexture?) -> Void) {
+        captureLock.lock()
+        _captureHandler = handler
+        captureLock.unlock()
     }
 
     override func nextDrawable() -> (any CAMetalDrawable)? {
         let d = super.nextDrawable()
-        drawableLock.lock()
-        _displayedDrawable = _pendingDrawable
-        _pendingDrawable = d
-        drawableLock.unlock()
+        guard let d else { return nil }
+
+        captureLock.lock()
+        let handler = _captureHandler
+        _captureHandler = nil
+        let queue = captureCommandQueue
+        let dst = captureTexture
+        captureLock.unlock()
+
+        if let handler {
+            var committed = false
+            if let queue, let dst,
+               let cmd = queue.makeCommandBuffer(),
+               let blit = cmd.makeBlitCommandEncoder() {
+                let src = d.texture
+                if src.width == dst.width, src.height == dst.height,
+                   src.pixelFormat == dst.pixelFormat {
+                    blit.copy(from: src, sourceSlice: 0, sourceLevel: 0,
+                              sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                              sourceSize: MTLSize(width: src.width, height: src.height, depth: 1),
+                              to: dst, destinationSlice: 0, destinationLevel: 0,
+                              destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+                    blit.endEncoding()
+                    cmd.addCompletedHandler { _ in handler(dst) }
+                    cmd.commit()
+                    committed = true
+                } else {
+                    blit.endEncoding()
+                }
+            }
+            // Always unblock the caller so its in-flight guard never gets stuck.
+            if !committed { handler(nil) }
+        }
+
         return d
     }
 
@@ -41,7 +92,7 @@ class MetalLayer: CAMetalLayer {
             }
         }
     }
-    
+
     // EDR layer control exists on iOS 16+/macOS only; CAMetalLayer has no
     // wantsExtendedDynamicRangeContent on tvOS at all. tvOS HDR is driven by
     // HDRDisplayMode (an AVDisplayManager HDMI display-mode switch) plus the


### PR DESCRIPTION
## What and why

I found a bug where if you left the macos player running the background after a while it would crash during the trickplay image capture with `EXC_BAD_ACCESS`. This PR fixes that.

stop crash caused by trickplay when in background
replace drawable-texture capture with GPU blit for trickplay

MoltenVK recycles the previous drawable inside super.nextDrawable(), making any access to its texture after that point a crash (EXC_BAD_ACCESS). Instead, blit from the newly acquired drawable's texture (which holds the frame from 2+ renders ago and is safe) into a persistent shared-memory texture before returning the drawable to mpv. The blit is async on a dedicated command queue so it adds no latency to the VO thread.

Also fixes tvOS trickplay not showing: metalLayer.device and drawableSize are not yet set at VIDEO_RECONFIG time, so the pipeline is now set up lazily from captureFrameJPEGData and retried each call until the device is ready.

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
