### PR TITLE
fix(player): add sport as a live type

### DIFF
--- a/app/SourcesShared/CoreModels.swift
+++ b/app/SourcesShared/CoreModels.swift
@@ -204,7 +204,7 @@ struct CoreBoardRow: Identifiable {
 /// path): broadcast TV, individual channels, and live events. Shared so the Live surface, the live
 /// detail branch, and the player all agree on what "live" means.
 enum LiveTypes {
-    static let all: Set<String> = ["tv", "channel", "events"]
+    static let all: Set<String> = ["tv", "channel", "events", "sport"]
     static func contains(_ type: String) -> Bool { all.contains(type) }
 }
 


### PR DESCRIPTION
## What and why

The service I was using had "sport" set to it's type for live tv. Without this change the player doesn't set to live mode and quits after a few seconds.

I don't think other add-ons are using sport as a fixed media, but I could be wrong. If so, we might need a better way of detecting if a stream is live so even if it doesn't appear under the live tab, it will at least play.

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
