### PR TITLE
feat: add SkipDB integration

### DIFF
--- a/app/Resources/Localizable.xcstrings
+++ b/app/Resources/Localizable.xcstrings
@@ -74580,7 +74580,11 @@
           }
         }
       }
-    }
+    },
+    "TheIntroDB": {},
+    "SkipDB": {},
+    "Both": {},
+    "Skip timestamps source": {}
   },
   "version": "1.0"
 }

--- a/app/Sources/Player/SkipTimestampService.swift
+++ b/app/Sources/Player/SkipTimestampService.swift
@@ -1,25 +1,37 @@
 import Foundation
 import os
 
-/// Layer 2: crowd-sourced skip timestamps from TheIntroDB (theintrodb.org), the community database
-/// behind several media-server skip plugins. Looked up by the IMDB id the app already has from
-/// Cinemeta (+ season/episode for series, nothing for movies); reads are anonymous. Results, and
-/// misses, cache to disk so an episode costs one request, not one per play, which also keeps us far
-/// inside the API's 30-requests-per-10s budget.
+/// Layer 2: crowd-sourced skip timestamps from TheIntroDB (theintrodb.org) and/or SkipDB
+/// (skipdb.tv). Looked up by the IMDB id the app already has from Cinemeta (+
+/// season/episode for series, nothing for movies); reads are anonymous. Results, and misses, cache
+/// to disk so an episode costs one request per provider, not one per play.
 enum SkipTimestampService {
 
-    /// Crowd spans for one title, as resolver candidates. Returns [] quietly on any failure: no
-    /// network, unknown title, or a non-IMDB id (some add-ons use their own id schemes) just means
-    /// the player falls back to the other layers, never an error surfaced mid-playback.
+    /// UserDefaults key for the chosen skip-timestamp provider.
+    /// Values: "theintrodb" (default), "skipdb", "both"
+    static let providerKey = "stremiox.skipProvider"
+
     private static let log = Logger(subsystem: "com.stremiox.app", category: "skiptimes")
 
-    /// All skip candidates for a title, merging TheIntroDB (any media) with AniSkip (anime), run
-    /// concurrently. Either source returning [] is normal; the player gets whatever was found and the
-    /// resolver's sanity guards clamp both, so an anime source can never cause a wild mid-episode skip.
+    private static var provider: String {
+        UserDefaults.standard.string(forKey: providerKey) ?? "both"
+    }
+
+    /// All skip candidates for a title, merging the chosen crowd source(s) with AniSkip (anime).
     static func candidates(imdbId: String, season: Int?, episode: Int?,
                            durationSeconds: Double) async -> [SegmentCandidate] {
         async let aniskip = AniSkipService.candidates(metaId: imdbId, episode: episode, durationSeconds: durationSeconds)
-        let crowd = await theIntroDB(imdbId: imdbId, season: season, episode: episode, durationSeconds: durationSeconds)
+        let crowd: [SegmentCandidate]
+        switch provider {
+        case "skipdb":
+            crowd = await skipDB(imdbId: imdbId, season: season, episode: episode, durationSeconds: durationSeconds)
+        case "both":
+            async let introdb = theIntroDB(imdbId: imdbId, season: season, episode: episode, durationSeconds: durationSeconds)
+            async let skipdb  = skipDB(imdbId: imdbId, season: season, episode: episode, durationSeconds: durationSeconds)
+            crowd = await introdb + skipdb
+        default: // "theintrodb"
+            crowd = await theIntroDB(imdbId: imdbId, season: season, episode: episode, durationSeconds: durationSeconds)
+        }
         return crowd + (await aniskip)
     }
 
@@ -27,7 +39,8 @@ enum SkipTimestampService {
     private static func theIntroDB(imdbId: String, season: Int?, episode: Int?,
                                    durationSeconds: Double) async -> [SegmentCandidate] {
         guard let idItem = queryItem(for: imdbId) else { return [] }
-        let key = "\(imdbId):\(season ?? 0):\(episode ?? 0)"
+        let durationBucket = Int(durationSeconds / 10) * 10
+        let key = "\(imdbId):\(season ?? 0):\(episode ?? 0):\(durationBucket)"
         if let cached = await SkipTimestampStore.shared.entry(for: key) {
             log.info("cache hit \(key, privacy: .public): \(cached.spans.count, privacy: .public) spans")
             return candidates(from: cached.spans, duration: durationSeconds)
@@ -67,6 +80,56 @@ enum SkipTimestampService {
             return candidates(from: media.spans, duration: durationSeconds)
         } catch {
             log.info("\(key, privacy: .public): failed, \(String(describing: error), privacy: .public)")
+            return []
+        }
+    }
+
+    /// Layer 2b: SkipDB crowd spans (any media, keyed by IMDB id only).
+    private static func skipDB(imdbId: String, season: Int?, episode: Int?,
+                               durationSeconds: Double) async -> [SegmentCandidate] {
+        guard imdbId.range(of: #"^tt\d{7,8}$"#, options: .regularExpression) != nil else { return [] }
+        let durationBucket = Int(durationSeconds / 10) * 10
+        let key = "skipdb:\(imdbId):\(season ?? 0):\(episode ?? 0):\(durationBucket)"
+        if let cached = await SkipTimestampStore.shared.entry(for: key) {
+            log.info("cache hit \(key, privacy: .public): \(cached.spans.count, privacy: .public) spans")
+            return candidates(from: cached.spans, duration: durationSeconds)
+        }
+
+        var components = URLComponents(string: "https://api.skipdb.tv/api/segments")!
+        var items: [URLQueryItem] = [URLQueryItem(name: "imdb_id", value: imdbId)]
+        if let season, let episode {
+            items.append(URLQueryItem(name: "season", value: String(season)))
+            items.append(URLQueryItem(name: "episode", value: String(episode)))
+        }
+        if durationSeconds > 0 {
+            items.append(URLQueryItem(name: "duration", value: String(Int(durationSeconds))))
+        }
+        components.queryItems = items
+        guard let url = components.url else { return [] }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return [] }
+            if http.statusCode == 404 {
+                log.info("\(key, privacy: .public): not in SkipDB")
+                await SkipTimestampStore.shared.store(.miss(), for: key)
+                return []
+            }
+            guard http.statusCode == 200 else {
+                log.info("\(key, privacy: .public): SkipDB HTTP \(http.statusCode, privacy: .public)")
+                return []
+            }
+            let raw = String(data: data, encoding: .utf8) ?? "<non-utf8>"
+            log.debug("SkipDB response for \(key, privacy: .public): \(raw, privacy: .public)")
+            let media = try JSONDecoder().decode(SkipDBResponse.self, from: data)
+            log.info("\(key, privacy: .public): \(media.spans.count, privacy: .public) spans from SkipDB")
+            let entry = SkipTimestampStore.Entry(fetchedAt: Date(), spans: media.spans)
+            await SkipTimestampStore.shared.store(entry, for: key)
+            return candidates(from: media.spans, duration: durationSeconds)
+        } catch {
+            log.info("\(key, privacy: .public): SkipDB failed, \(String(describing: error), privacy: .public)")
             return []
         }
     }
@@ -117,6 +180,36 @@ enum SkipTimestampService {
             }
             return stored(intro, "intro") + stored(recap, "recap")
                 + stored(credits, "credits") + stored(preview, "preview")
+        }
+    }
+
+    /// SkipDB `/api/segments` shape: one object per type (or null / excluded marker).
+    /// `outro` is SkipDB's name for end-credits — mapped to the `"credits"` kind.
+    private struct SkipDBResponse: Decodable {
+        struct Span: Decodable {
+            let start_ms: Int?
+            let end_ms: Int?
+        }
+        struct Segments: Decodable {
+            let intro:   Span?
+            let recap:   Span?
+            let outro:   Span?   // mapped to kind "credits"
+            let preview: Span?
+        }
+        let segments: Segments
+
+        var spans: [StoredSpan] {
+            func stored(_ span: Span?, kind: String) -> StoredSpan? {
+                // Excluded entries decode as Span with both fields nil; real segments have start_ms.
+                guard let s = span, s.start_ms != nil else { return nil }
+                return StoredSpan(kind: kind, startMs: s.start_ms, endMs: s.end_ms)
+            }
+            return [
+                stored(segments.intro,   kind: "intro"),
+                stored(segments.recap,   kind: "recap"),
+                stored(segments.outro,   kind: "credits"),
+                stored(segments.preview, kind: "preview"),
+            ].compactMap { $0 }
         }
     }
 }

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
     @AppStorage(PlaybackSettings.Key.videoUpscaling) private var videoUpscaling = PlaybackSettings.videoUpscaling.rawValue
     @AppStorage("stremiox.seekStep") private var seekStep = "10"   // skip step in seconds, shared with the player
     @AppStorage("stremiox.autoSkip") private var autoSkip = false  // auto-skip intro/credits, shared with iOS/Mac
+    @AppStorage(SkipTimestampService.providerKey) private var skipProvider = "both"
     @AppStorage(ExternalPlayers.defaultKey) private var defaultExternalPlayer = ""   // "" == built-in libmpv
     @ObservedObject private var sourcePrefs = SourcePreferences.shared
 
@@ -211,6 +212,8 @@ struct SettingsView: View {
             choiceRow("Skip step", [("10", "10s"), ("15", "15s"), ("30", "30s")], selection: $seekStep)
             choiceRow("Auto-skip intro & credits", [("0", "Off"), ("1", "On")],
                       selection: Binding(get: { autoSkip ? "1" : "0" }, set: { autoSkip = ($0 == "1") }))
+            choiceRow("Skip timestamps source", [("theintrodb", "TheIntroDB"), ("skipdb", "SkipDB"), ("both", "Both")],
+                      selection: $skipProvider)
             choiceRow("Play in", externalPlayerChoices, selection: $defaultExternalPlayer)
             Text("Direct and debrid streams open in your chosen player automatically. Torrents and the built-in player are unaffected.")
                 .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)

--- a/app/SourcesiOS/iOSSettingsView.swift
+++ b/app/SourcesiOS/iOSSettingsView.swift
@@ -51,6 +51,7 @@ struct iOSSettingsView: View {
     @AppStorage(PlayerEngineRouter.overrideKey) private var playerEngine = PlayerEngineRouter.Override.auto.rawValue
     #endif
     @AppStorage("stremiox.autoSkip") private var autoSkip = false
+    @AppStorage(SkipTimestampService.providerKey) private var skipProvider = "both"
     @AppStorage("stremiox.autoplayTrailers") private var autoplayTrailers = true
     // Empty string == built-in libmpv player; otherwise an ExternalPlayer.Target id to auto-open in.
     @AppStorage(ExternalPlayer.defaultKey) private var defaultExternalPlayer = ""
@@ -363,6 +364,11 @@ struct iOSSettingsView: View {
             }
             Toggle("Auto-skip intro & credits", isOn: $autoSkip)
                 .tint(Theme.Palette.accent)
+            Picker("Skip timestamps source", selection: $skipProvider) {
+                Text("TheIntroDB").tag("theintrodb")
+                Text("SkipDB").tag("skipdb")
+                Text("Both").tag("both")
+            }
             NavigationLink("Seek bar style") { SeekBarStylePicker() }
             Toggle("Autoplay trailers", isOn: $autoplayTrailers)
                 .tint(Theme.Palette.accent)


### PR DESCRIPTION
## What and why

Add SkipDB (https://skipdb.tv) as an alternative to theIntroDB

Following on from this post on Reddit https://www.reddit.com/r/Nuvio/comments/1udr3qn (in Nuvio as there are more active users and they have the same issue)

Both the current main providers IntroDB and TheIntroDB maintain proprietary databases of skip segments even though they are based on crowdsourced user contributions. When approaching the maintainers, both seem to be refusing to open the data. This puts the data a risk to being locked down behind a paywall or lost.

I've already built up decent coverage of the most popular series. All segments are independently sourced - nothing borrowed or derived from the other intro databases.

Both services are only around 6 months old (less I think), so we're not that far behind to create an open alternative. SkipDB provides all it's data openly (with the only restriction being that the other services aren't allowed to use the data without opening up their database). Anyone can run a read-only mirror or just completely self host an alternative without losing user contributions. If SkipDB stopped running, then the only change needed would be updating the url in VortX to a mirror. We could even allow a custom url to be set by users if mirrors do start appearing in the future.

I plan to follow up with an interface to submit segments. It's already built as I've been using it to submit some segments myself, but I need to make some UI improvements before I open a PR.

## Screenshots

<!-- Before/after for anything visual. Simulator screenshots are fine. -->

## Checks

- [ ] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [ ] Screenshots attached for UI changes
