### PR TITLE
feat(macos,ios): Add SkipDB segment submission

### DIFF
--- a/app/Resources/Localizable.xcstrings
+++ b/app/Resources/Localizable.xcstrings
@@ -74584,7 +74584,21 @@
     "TheIntroDB": {},
     "SkipDB": {},
     "Both": {},
-    "Skip timestamps source": {}
+    "Skip timestamps source": {},
+    "Add a custom end time": {},
+    "Close editor": {},
+    "Close SkipDB editor": {},
+    "Edit SkipDB segments": {},
+    "episode end": {},
+    "Jump to end": {},
+    "Jump to start": {},
+    "Next chapter": {},
+    "Preview: plays 2s before start, jumps to end": {},
+    "Previous chapter": {},
+    "Resubmit": {},
+    "Set to playhead": {},
+    "Submitted!": {},
+    "Use episode end instead": {}
   },
   "version": "1.0"
 }

--- a/app/Sources/Player/SkipTimestampService.swift
+++ b/app/Sources/Player/SkipTimestampService.swift
@@ -109,6 +109,9 @@ enum SkipTimestampService {
 
         var request = URLRequest(url: url)
         request.timeoutInterval = 5
+        if let apiKey = ApiKeys.skipDBKey() {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else { return [] }
@@ -125,7 +128,8 @@ enum SkipTimestampService {
             log.debug("SkipDB response for \(key, privacy: .public): \(raw, privacy: .public)")
             let media = try JSONDecoder().decode(SkipDBResponse.self, from: data)
             log.info("\(key, privacy: .public): \(media.spans.count, privacy: .public) spans from SkipDB")
-            let entry = SkipTimestampStore.Entry(fetchedAt: Date(), spans: media.spans)
+            let entry = SkipTimestampStore.Entry(fetchedAt: Date(), spans: media.spans,
+                                                 introEstimateMs: media.intro_length_estimate_ms)
             await SkipTimestampStore.shared.store(entry, for: key)
             return candidates(from: media.spans, duration: durationSeconds)
         } catch {
@@ -197,10 +201,10 @@ enum SkipTimestampService {
             let preview: Span?
         }
         let segments: Segments
+        let intro_length_estimate_ms: Int?
 
         var spans: [StoredSpan] {
             func stored(_ span: Span?, kind: String) -> StoredSpan? {
-                // Excluded entries decode as Span with both fields nil; real segments have start_ms.
                 guard let s = span, s.start_ms != nil else { return nil }
                 return StoredSpan(kind: kind, startMs: s.start_ms, endMs: s.end_ms)
             }
@@ -230,7 +234,8 @@ actor SkipTimestampStore {
     struct Entry: Codable {
         let fetchedAt: Date
         let spans: [StoredSpan]
-        static func miss() -> Entry { Entry(fetchedAt: Date(), spans: []) }
+        var introEstimateMs: Int?               // intro_length_estimate_ms from SkipDB (nil = not set or no data)
+        static func miss() -> Entry { Entry(fetchedAt: Date(), spans: [], introEstimateMs: nil) }
     }
 
     private var entries: [String: Entry]?
@@ -251,6 +256,19 @@ actor SkipTimestampStore {
     func store(_ entry: Entry, for key: String) {
         loadIfNeeded()
         entries?[key] = entry
+        if let data = try? JSONEncoder().encode(entries) {
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    func introEstimate(for key: String) -> Int? {
+        loadIfNeeded()
+        return entries?[key]?.introEstimateMs
+    }
+
+    func invalidate(for key: String) {
+        loadIfNeeded()
+        entries?[key] = nil
         if let data = try? JSONEncoder().encode(entries) {
             try? data.write(to: fileURL, options: .atomic)
         }

--- a/app/Sources/PlayerScreen.swift
+++ b/app/Sources/PlayerScreen.swift
@@ -198,6 +198,19 @@ struct PlayerScreen: View {
     @State private var sleepDeadline: Date? = nil       // when the timed pause fires (for the countdown label)
     @State private var sleepTask: Task<Void, Never>?
     @State private var showExternalChooser = false   // "Play in another app" sheet
+    // SkipDB segment editor state.
+    @State private var showSkipDBEdit = false
+    @State private var skipDBEditType: SkipDBSubmitView.SegmentType = .intro
+    @State private var skipDBEditStart: Double = 0
+    @State private var skipDBEditEnd: Double = 30
+    @State private var skipDBSubmitting = false
+    @State private var skipDBSubmitResult: Bool? = nil
+    @State private var skipDBSubmitError: String? = nil
+    @State private var skipDBSubmittedKeys: Set<String> = []
+    @State private var skipDBPreviewing = false
+    @State private var skipDBShowEndTime = true
+    @State private var skipDBIntroEstimateMs: Int? = nil
+    @ObservedObject private var apiKeys = ApiKeys.shared
     @State private var externalLinkDead = false      // pre-flight probe found the stream URL dead before handoff
     @State private var subtitleLoadFailed = false    // an add-on subtitle download timed out / failed
     @State private var warmedEpisodeID: String?      // next-episode source already warmed this episode (F6 preload)
@@ -529,6 +542,10 @@ struct PlayerScreen: View {
                 }
                 if !scrubbing {
                     currentTime = d
+                    if skipDBPreviewing, d >= skipDBEditStart {
+                        skipDBPreviewing = false
+                        coordinator.player?.seek(to: skipDBEditEnd)
+                    }
                     updateCurrentSkip(at: d)
                     NowPlayingCenter.update(title: curTitle, elapsed: d, duration: duration, paused: isPaused)
                     maybeCaptureLocalTrickplay(at: d)
@@ -620,11 +637,11 @@ struct PlayerScreen: View {
                 // auto-advancing. The episode is already marked watched above, so Continue Watching
                 // rolls to the next episode on its own without yanking the viewer out of the credits.
                 onClose()
-            } else if canNextEpisode, let i = episodeIndex {
+            } else if canNextEpisode, let i = episodeIndex, !showSkipDBEdit {
                 goToEpisode(episodes[i + 1].id, autoAdvance: true)   // in-place advance to the next episode
-            } else if hasNext {
+            } else if hasNext, !showSkipDBEdit {
                 onNext()                                  // legacy non-episode caller
-            } else {
+            } else if !showSkipDBEdit {
                 // Finished (movie or last episode): rewind the title OUT of Continue Watching. The engine
                 // keeps any item with time_offset > 0 in the rail, so without this a finished title lingers
                 // at its end position forever (the "CW never clears" report). Mirrors tvOS autoAdvance:1479.
@@ -1058,7 +1075,7 @@ struct PlayerScreen: View {
     /// episode queued, a real runtime, the play head in the final stretch, and the user hasn't chosen to
     /// sit through the credits. nil hides the band. The EOF handler does the actual advance at 0.
     private var upNextRemaining: Int? {
-        guard canNextEpisode, !upNextSuppressed, duration > 60, currentTime > 0 else { return nil }
+        guard canNextEpisode, !upNextSuppressed, !showSkipDBEdit, duration > 60, currentTime > 0 else { return nil }
         let remaining = duration - currentTime
         guard remaining > 0, remaining <= 20 else { return nil }
         return Int(remaining.rounded(.up))
@@ -1294,6 +1311,23 @@ struct PlayerScreen: View {
                     scheduleHide()
                 }
             }
+            if apiKeys.hasSkipDB, let m = curMeta,
+               m.libraryId.range(of: #"^tt\d{7,8}$"#, options: .regularExpression) != nil {
+                iconButton(showSkipDBEdit ? "checkmark.bubble.fill" : "checkmark.bubble",
+                           label: showSkipDBEdit ? "Close SkipDB editor" : "Edit SkipDB segments") {
+                    if !showSkipDBEdit {
+                        let snapped = (currentTime * 2).rounded() / 2
+                        skipDBEditStart = max(0, snapped)
+                        skipDBEditEnd = min(snapped + 30, duration > 0 ? duration : snapped + 60)
+                        skipDBEditType = .intro
+                        skipDBShowEndTime = true
+                        skipDBSubmitResult = nil
+                        skipDBSubmitError = nil
+                        skipDBPreviewing = false
+                    }
+                    showSkipDBEdit.toggle()
+                }
+            }
             iconButton("gearshape", label: "Player settings") { openPanel(.playerSettings) }   // decoder toggle + playback info (tvOS parity #22)
             iconButton("arrow.up.forward.app", label: "Play in another app") {       // hand off to Infuse / VLC / Share
                 hideTask?.cancel()
@@ -1403,6 +1437,47 @@ struct PlayerScreen: View {
                             }
                             .allowsHitTesting(false)
                         }
+                        // Loaded skip segments — faint coloured bands.
+                        .overlay {
+                            if duration > 0 {
+                                ForEach(skipSegments) { seg in
+                                    let sf = CGFloat(seg.start / duration)
+                                    let ef = CGFloat(seg.end / duration)
+                                    let sx = sliderInset + sf * trackWidth
+                                    let w  = max(2, (ef - sf) * trackWidth)
+                                    Capsule().fill(seg.kind == .intro ? Color.cyan.opacity(0.45)
+                                                   : seg.kind == .recap ? Color.yellow.opacity(0.45)
+                                                   : seg.kind == .credits ? Color.purple.opacity(0.45)
+                                                   : Color.orange.opacity(0.45))
+                                        .frame(width: w, height: 5)
+                                        .position(x: sx + w / 2, y: geo.size.height / 2)
+                                }
+                                .allowsHitTesting(false)
+                            }
+                        }
+                        // Segment being edited — bright band + start/end markers.
+                        .overlay {
+                            if showSkipDBEdit, duration > 0 {
+                                let sf = CGFloat(skipDBEditStart / duration)
+                                let ef = CGFloat(skipDBEditEnd   / duration)
+                                let sx = sliderInset + sf * trackWidth
+                                let ex = sliderInset + ef * trackWidth
+                                let w  = max(2, ex - sx)
+                                let cy = geo.size.height / 2
+                                ZStack(alignment: .topLeading) {
+                                    Rectangle().fill(Color.white.opacity(0.35))
+                                        .frame(width: w, height: 6)
+                                        .position(x: sx + w / 2, y: cy)
+                                    Capsule().fill(Color.white)
+                                        .frame(width: 3, height: 14)
+                                        .position(x: sx, y: cy)
+                                    Capsule().fill(Color.white)
+                                        .frame(width: 3, height: 14)
+                                        .position(x: ex, y: cy)
+                                }
+                                .allowsHitTesting(false)
+                            }
+                        }
                         // bottomLeading alignment: popup bottom anchors at slider bottom, grows upward.
                         // y: -28 lifts it 4 pt above the slider top (slider is 24 pt tall).
                         .overlay(alignment: .bottomLeading) {
@@ -1424,6 +1499,8 @@ struct PlayerScreen: View {
                     }
                 }
             }
+
+            if showSkipDBEdit, let m = curMeta { skipDBEditBar(meta: m) }
 
             HStack(spacing: 0) {
                 controlButton("speedometer", speed == 1.0 ? "Speed" : speedLabel(speed)) { openPanel(.speed) }
@@ -1459,6 +1536,321 @@ struct PlayerScreen: View {
             .padding(.horizontal, 8)
         }
         .padding(.horizontal).padding(.bottom, 22)
+    }
+
+    // MARK: - SkipDB edit bar
+
+    @ViewBuilder private func skipDBEditBar(meta: PlaybackMeta) -> some View {
+        let submittedKey = "\(meta.libraryId):\(meta.season ?? 0):\(meta.episode ?? 0):\(skipDBEditType.rawValue)"
+        let alreadySubmitted = skipDBSubmittedKeys.contains(submittedKey)
+        let segDuration = skipDBEditEnd - skipDBEditStart
+
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                // Left: type picker + chapter nav
+                HStack(spacing: 6) {
+                    Text("SkipDB")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.45))
+                    Menu {
+                        ForEach(SkipDBSubmitView.SegmentType.allCases) { t in
+                            Button {
+                                skipDBEditType = t
+                                skipDBSubmitResult = nil
+                                skipDBSubmitError = nil
+                                if t == .outro {
+                                    skipDBShowEndTime = false
+                                    skipDBEditEnd = duration > 0 ? duration : skipDBEditEnd
+                                } else {
+                                    skipDBShowEndTime = true
+                                }
+                            } label: {
+                                let k = "\(meta.libraryId):\(meta.season ?? 0):\(meta.episode ?? 0):\(t.rawValue)"
+                                Label(t.label, systemImage: skipDBSubmittedKeys.contains(k) ? "checkmark" : "")
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(skipDBEditType.label).font(.caption.weight(.semibold))
+                            Image(systemName: "chevron.up.chevron.down").font(.caption2)
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(.white.opacity(0.15), in: Capsule())
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+
+                    if hasChapters {
+                        let boundaries = chapterFractions.map { $0 * duration }
+                        let prevCh = boundaries.last(where: { $0 < currentTime - 1.0 })
+                        let nextCh = boundaries.first(where: { $0 > currentTime + 0.5 })
+                        HStack(spacing: 2) {
+                            Button {
+                                if let t = prevCh { coordinator.player?.seek(to: t) }
+                            } label: {
+                                Image(systemName: "backward.end.fill").font(.caption)
+                                    .foregroundStyle(prevCh != nil ? .white : .white.opacity(0.3))
+                                    .padding(4)
+                            }
+                            .buttonStyle(.plain).disabled(prevCh == nil)
+                            .skipDBTooltip("Previous chapter")
+                            Button {
+                                if let t = nextCh { coordinator.player?.seek(to: t) }
+                            } label: {
+                                Image(systemName: "forward.end.fill").font(.caption)
+                                    .foregroundStyle(nextCh != nil ? .white : .white.opacity(0.3))
+                                    .padding(4)
+                            }
+                            .buttonStyle(.plain).disabled(nextCh == nil)
+                            .skipDBTooltip("Next chapter")
+                        }
+                        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+
+                Spacer()
+
+                // Middle: start / end time controls
+                HStack(spacing: 6) {
+                    skipDBTimeControl(label: "Start", seconds: $skipDBEditStart, isEnd: false)
+
+                    if skipDBEditType == .outro && !skipDBShowEndTime {
+                        Button {
+                            skipDBShowEndTime = true
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text("End").font(.caption2).foregroundStyle(.white.opacity(0.5))
+                                Text("episode end")
+                                    .font(.caption2.monospacedDigit())
+                                    .foregroundStyle(.white.opacity(0.35))
+                                Image(systemName: "plus.circle")
+                                    .font(.caption2)
+                                    .foregroundStyle(.white.opacity(0.55))
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .skipDBTooltip("Add a custom end time")
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                    } else {
+                        Text(String(format: "%.1fs", max(0, segDuration)))
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.white.opacity(0.4))
+                            .frame(minWidth: 34, alignment: .center)
+
+                        skipDBTimeControl(label: "End", seconds: $skipDBEditEnd, isEnd: true)
+
+                        if skipDBEditType == .outro {
+                            Button {
+                                skipDBShowEndTime = false
+                                skipDBEditEnd = duration > 0 ? duration : skipDBEditEnd
+                            } label: {
+                                Image(systemName: "xmark.circle")
+                                    .font(.caption2)
+                                    .foregroundStyle(.white.opacity(0.5))
+                            }
+                            .buttonStyle(.plain)
+                            .skipDBTooltip("Use episode end instead")
+                        }
+
+                        if skipDBEditType == .intro, let estimateMs = skipDBIntroEstimateMs {
+                            let suggestedEnd = skipDBEditStart + Double(estimateMs) / 1000
+                            if abs(suggestedEnd - skipDBEditEnd) > 3 {
+                                Button {
+                                    skipDBEditEnd = (suggestedEnd * 10).rounded() / 10
+                                } label: {
+                                    HStack(spacing: 3) {
+                                        Image(systemName: "wand.and.stars").font(.caption2)
+                                        Text(skipDBFormatTime(suggestedEnd)).font(.caption2.monospacedDigit())
+                                    }
+                                    .foregroundStyle(.yellow.opacity(0.85))
+                                    .padding(.horizontal, 6).padding(.vertical, 3)
+                                    .background(.yellow.opacity(0.15), in: Capsule())
+                                }
+                                .buttonStyle(.plain)
+                                .skipDBTooltip("Typical intro end for this series (+\(Int(Double(estimateMs) / 1000))s from start)")
+                            }
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // Right: preview + submit + close
+                HStack(spacing: 8) {
+                    Button {
+                        skipDBPreviewing = true
+                        coordinator.player?.seek(to: max(0, skipDBEditStart - 2))
+                        if isPaused { coordinator.player?.togglePause() }
+                    } label: {
+                        Image(systemName: skipDBPreviewing ? "stop.circle.fill" : "play.circle")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(skipDBPreviewing ? Color.yellow : .white)
+                            .padding(5)
+                    }
+                    .buttonStyle(.plain)
+                    .skipDBTooltip("Preview: plays 2s before start, jumps to end")
+
+                    if skipDBSubmitting {
+                        ProgressView().controlSize(.small).tint(.white).padding(.horizontal, 4)
+                    } else if skipDBSubmitResult == true {
+                        Label("Submitted!", systemImage: "checkmark.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                            .onTapGesture { skipDBSubmitResult = nil }
+                    } else {
+                        Button {
+                            Task { await doSkipDBSubmit(meta: meta) }
+                        } label: {
+                            Text(alreadySubmitted ? "Resubmit" : "Submit")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 10).padding(.vertical, 5)
+                                .background(alreadySubmitted ? Color.yellow : Color.white, in: Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(skipDBEditStart >= skipDBEditEnd)
+                    }
+
+                    Button {
+                        showSkipDBEdit = false
+                        skipDBPreviewing = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.white.opacity(0.6))
+                            .padding(5)
+                    }
+                    .buttonStyle(.plain)
+                    .skipDBTooltip("Close editor")
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            if let err = skipDBSubmitError {
+                Text(err).font(.caption2).foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.5), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .padding(.horizontal, 8)
+    }
+
+    @ViewBuilder private func skipDBTimeControl(label: String, seconds: Binding<Double>, isEnd: Bool) -> some View {
+        HStack(spacing: 4) {
+            Button {
+                coordinator.player?.seek(to: seconds.wrappedValue)
+            } label: {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+            .buttonStyle(.plain)
+            .skipDBTooltip(isEnd ? "Jump to end" : "Jump to start")
+
+            Button {
+                let snapped = (currentTime * 10).rounded() / 10
+                seconds.wrappedValue = max(0, snapped)
+            } label: {
+                Image(systemName: "arrow.down.to.line")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+            .skipDBTooltip("Set to playhead")
+
+            Text(skipDBFormatTime(seconds.wrappedValue))
+                .font(.caption.monospacedDigit()).foregroundStyle(.white)
+                .frame(minWidth: 44, alignment: .center)
+
+            HStack(spacing: 2) {
+                skipDBNudgeButton(seconds: seconds, delta: -0.5, label: "−½")
+                skipDBNudgeButton(seconds: seconds, delta: -0.1, label: "−·")
+                skipDBNudgeButton(seconds: seconds, delta: +0.1, label: "+·")
+                skipDBNudgeButton(seconds: seconds, delta: +0.5, label: "+½")
+            }
+        }
+        .padding(.horizontal, 7).padding(.vertical, 4)
+        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+    }
+
+    @ViewBuilder private func skipDBNudgeButton(seconds: Binding<Double>, delta: Double, label: String) -> some View {
+        Button {
+            let cap = duration > 0 ? duration : Double.greatestFiniteMagnitude
+            seconds.wrappedValue = min(cap, max(0, seconds.wrappedValue + delta))
+        } label: {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                .frame(width: 20, height: 20)
+                .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 4))
+                .foregroundStyle(.white)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func skipDBFormatTime(_ sec: Double) -> String {
+        let total = max(0, sec)
+        let m = Int(total) / 60
+        let s = total - Double(m * 60)
+        return String(format: "%d:%04.1f", m, s)
+    }
+
+    fileprivate struct SkipDBHoverTooltip: ViewModifier {
+        let text: String
+        @State private var hovered = false
+        func body(content: Content) -> some View {
+            content
+                .onHover { hovered = $0 }
+                .overlay(alignment: .top) {
+                    if hovered {
+                        Text(text)
+                            .font(.system(size: 10))
+                            .lineLimit(1)
+                            .padding(.horizontal, 6).padding(.vertical, 3)
+                            .background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 4))
+                            .foregroundStyle(.white)
+                            .fixedSize()
+                            .offset(y: -20)
+                            .allowsHitTesting(false)
+                            .transition(.opacity)
+                            .zIndex(999)
+                    }
+                }
+        }
+    }
+
+    private func doSkipDBSubmit(meta: PlaybackMeta) async {
+        skipDBSubmitting = true
+        skipDBSubmitError = nil
+        let effectiveEnd = (!skipDBShowEndTime && duration > 0) ? duration : skipDBEditEnd
+        let req = SkipDBClient.SubmitRequest(
+            imdb_id: meta.libraryId,
+            season: meta.season,
+            episode: meta.episode,
+            segment_type: skipDBEditType.rawValue,
+            start_ms: Int(skipDBEditStart * 1000),
+            end_ms: Int(effectiveEnd * 1000),
+            duration_ms: duration > 0 ? Int(duration * 1000) : nil
+        )
+        do {
+            try await SkipDBClient.submit(req)
+            await SkipDBClient.invalidateCache(imdbId: meta.libraryId, season: meta.season,
+                                               episode: meta.episode, durationSeconds: duration)
+            let key = "\(meta.libraryId):\(meta.season ?? 0):\(meta.episode ?? 0):\(skipDBEditType.rawValue)"
+            skipDBSubmittedKeys.insert(key)
+            skipDBSubmitResult = true
+            skipFetchKey = ""
+            fetchSkipTimestamps()
+        } catch {
+            skipDBSubmitResult = false
+            skipDBSubmitError = error.localizedDescription
+        }
+        skipDBSubmitting = false
     }
 
     /// The Live position indicator shown in place of the scrubber: a pulsing red dot + "LIVE", and a
@@ -1538,6 +1930,7 @@ struct PlayerScreen: View {
             withAnimation(.easeInOut(duration: 0.2)) { currentSkip = skip }
         }
     }
+
     private func refreshSkipSegments() {
         let chapters = coordinator.player?.chapters() ?? []
         let chapterCandidates = SkipSegments.chapterCandidates(chapters: chapters, duration: duration)
@@ -1545,6 +1938,7 @@ struct PlayerScreen: View {
         chapterFractions = ChapterMarks.fractions(chapters: chapters, duration: duration)
         updateCurrentSkip(at: currentTime)
     }
+
     private func fetchSkipTimestamps() {
         guard let m = curMeta, SkipTimestampService.supports(metaId: m.libraryId) else {
             skipFetchTask?.cancel(); apiSkipCandidates = []; skipFetchKey = ""; refreshSkipSegments(); return
@@ -1562,6 +1956,7 @@ struct PlayerScreen: View {
             guard !Task.isCancelled, skipFetchKey == key else { return }
             apiSkipCandidates = found
             refreshSkipSegments()
+            skipDBIntroEstimateMs = await SkipTimestampStore.shared.introEstimate(for: "skipdb:\(key):\(Int(dur / 10) * 10)")
         }
     }
 
@@ -2099,7 +2494,7 @@ struct PlayerScreen: View {
             // Never auto-hide before the first frame arrives: a stuck pre-start load must KEEP its
             // controls (and their close button) on screen so the player is never a trap. Also hold
             // while scrubbing, a panel is open, or paused.
-            guard !Task.isCancelled, hasStartedPlaying, !scrubbing, panel == nil, !isPaused else { return }
+            guard !Task.isCancelled, hasStartedPlaying, !scrubbing, panel == nil, !isPaused, !showSkipDBEdit else { return }
             withAnimation(.easeInOut(duration: 0.2)) { controlsVisible = false }
         }
     }
@@ -2110,5 +2505,11 @@ struct PlayerScreen: View {
         guard t.isFinite, t >= 0 else { return "0:00" }
         let total = Int(t), h = total / 3600, m = (total % 3600) / 60, s = total % 60
         return h > 0 ? String(format: "%d:%02d:%02d", h, m, s) : String(format: "%d:%02d", m, s)
+    }
+}
+
+private extension View {
+    func skipDBTooltip(_ text: String) -> some View {
+        modifier(PlayerScreen.SkipDBHoverTooltip(text: text))
     }
 }

--- a/app/SourcesShared/ApiKeys.swift
+++ b/app/SourcesShared/ApiKeys.swift
@@ -9,17 +9,21 @@ final class ApiKeys: ObservableObject {
 
     private let tmdbAccount = "vortx.apikey.tmdb"
     private let mdblistAccount = "vortx.apikey.mdblist"
+    private let skipdbAccount = "vortx.apikey.skipdb"
 
     @Published var tmdb: String { didSet { Keychain.set(tmdb.isEmpty ? nil : tmdb, for: tmdbAccount); VortXSyncManager.shared.requestSyncSoon() } }
     @Published var mdblist: String { didSet { Keychain.set(mdblist.isEmpty ? nil : mdblist, for: mdblistAccount); VortXSyncManager.shared.requestSyncSoon() } }
+    @Published var skipdb: String { didSet { Keychain.set(skipdb.isEmpty ? nil : skipdb, for: skipdbAccount); VortXSyncManager.shared.requestSyncSoon() } }
 
     private init() {
         tmdb = Keychain.string(tmdbAccount) ?? ""
         mdblist = Keychain.string(mdblistAccount) ?? ""
+        skipdb = Keychain.string(skipdbAccount) ?? ""
     }
 
     var hasTMDB: Bool { !tmdb.isEmpty }
     var hasMDBList: Bool { !mdblist.isEmpty }
+    var hasSkipDB: Bool { !skipdb.isEmpty }
 
     /// Read the keys off the main actor (for use inside async network code).
     nonisolated static func tmdbKey() -> String? {
@@ -27,5 +31,8 @@ final class ApiKeys: ObservableObject {
     }
     nonisolated static func mdblistKey() -> String? {
         let k = Keychain.string("vortx.apikey.mdblist"); return (k?.isEmpty == false) ? k : nil
+    }
+    nonisolated static func skipDBKey() -> String? {
+        let k = Keychain.string("vortx.apikey.skipdb"); return (k?.isEmpty == false) ? k : nil
     }
 }

--- a/app/SourcesShared/MetadataKeysView.swift
+++ b/app/SourcesShared/MetadataKeysView.swift
@@ -9,11 +9,12 @@ struct MetadataKeysView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: Theme.Space.lg) {
                 Text("Metadata services").screenTitleStyle()
-                Text("Optional. Add your own TMDB and MDBList keys to enrich recommendations and ratings. Nothing here is required and your keys stay on this device (and sync, encrypted, to your VortX account).")
+                Text("Optional. Add your own TMDB and MDBList keys to enrich recommendations and ratings. Add a SkipDB key to submit and correct skip segments from the player. Keys stay on this device (and sync, encrypted, to your VortX account).")
                     .font(Theme.Typography.body)
                     .foregroundStyle(Theme.Palette.textSecondary)
                 keyField("TMDB", text: $keys.tmdb, hint: "Free at themoviedb.org, Settings then API.")
                 keyField("MDBList", text: $keys.mdblist, hint: "Free at mdblist.com, Preferences then API.")
+                keyField("SkipDB", text: $keys.skipdb, hint: "Create an account at skipdb.tv, then generate an API key in Account settings.")
             }
             .padding(.horizontal, Theme.Space.screenInset)
             .padding(.vertical, Theme.Space.xl)

--- a/app/SourcesShared/SkipDBClient.swift
+++ b/app/SourcesShared/SkipDBClient.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Submission client for api.skipdb.tv. Reads are handled by SkipTimestampService;
+/// this handles authenticated writes (POST a segment) and cache invalidation after a submit.
+enum SkipDBClient {
+
+    enum SkipDBError: LocalizedError {
+        case noKey
+        case serverError(Int, String?)
+        var errorDescription: String? {
+            switch self {
+            case .noKey:
+                return "No SkipDB API key. Add one in Settings → Metadata services."
+            case .serverError(let code, let msg):
+                return msg ?? "SkipDB returned \(code)"
+            }
+        }
+    }
+
+    struct SubmitRequest: Encodable {
+        let imdb_id: String
+        let season: Int?
+        let episode: Int?
+        let segment_type: String
+        let start_ms: Int
+        let end_ms: Int
+        let duration_ms: Int?
+    }
+
+    static func submit(_ req: SubmitRequest) async throws {
+        guard let key = ApiKeys.skipDBKey() else { throw SkipDBError.noKey }
+        guard let url = URL(string: "https://api.skipdb.tv/api/segments") else { return }
+        var urlReq = URLRequest(url: url)
+        urlReq.httpMethod = "POST"
+        urlReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlReq.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        urlReq.httpBody = try JSONEncoder().encode(req)
+        urlReq.timeoutInterval = 10
+        let (data, response) = try await URLSession.shared.data(for: urlReq)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        guard (200..<300).contains(http.statusCode) else {
+            let msg = try? JSONDecoder().decode([String: String].self, from: data)
+            throw SkipDBError.serverError(http.statusCode, msg?["error"])
+        }
+    }
+
+    /// Remove the cached SkipDB entry for an episode so the next fetch gets fresh data.
+    static func invalidateCache(imdbId: String, season: Int?, episode: Int?, durationSeconds: Double) async {
+        let bucket = Int(durationSeconds / 10) * 10
+        let key = "skipdb:\(imdbId):\(season ?? 0):\(episode ?? 0):\(bucket)"
+        await SkipTimestampStore.shared.invalidate(for: key)
+    }
+}

--- a/app/SourcesShared/SkipDBSubmitView.swift
+++ b/app/SourcesShared/SkipDBSubmitView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+/// Sheet for submitting or correcting skip segments to SkipDB. Opened from the player while
+/// an episode is playing; pre-fills times from the current playhead so users can scrub to the
+/// right point and tap Submit.
+struct SkipDBSubmitView: View {
+    let imdbId: String
+    let season: Int?
+    let episode: Int?
+    let episodeTitle: String
+    let currentTimeSec: Double
+    let durationSec: Double
+    /// Already-resolved segments from the player (all sources). Shown so the user can tap one
+    /// to correct it rather than re-entering times from scratch.
+    let existingSegments: [SkipDBSegmentItem]
+    let onSubmitted: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedType: SegmentType = .intro
+    @State private var startSec: Double
+    @State private var endSec: Double
+    @State private var submitting = false
+    @State private var submitResult: SubmitResult?
+
+    enum SegmentType: String, CaseIterable, Identifiable {
+        case intro, recap, outro, preview
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .intro: "Intro"
+            case .recap: "Recap"
+            case .outro: "Outro / Credits"
+            case .preview: "Preview"
+            }
+        }
+    }
+
+    enum SubmitResult {
+        case success
+        case failure(String)
+    }
+
+    init(imdbId: String, season: Int?, episode: Int?, episodeTitle: String,
+         currentTimeSec: Double, durationSec: Double,
+         existingSegments: [SkipDBSegmentItem], onSubmitted: @escaping () -> Void) {
+        self.imdbId = imdbId
+        self.season = season
+        self.episode = episode
+        self.episodeTitle = episodeTitle
+        self.currentTimeSec = currentTimeSec
+        self.durationSec = durationSec
+        self.existingSegments = existingSegments
+        self.onSubmitted = onSubmitted
+        // Pre-fill start to current playhead; end to start + 30s as a sane default.
+        _startSec = State(initialValue: max(0, currentTimeSec))
+        _endSec   = State(initialValue: max(currentTimeSec + 30, currentTimeSec + 1))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                episodeSection
+                if !existingSegments.isEmpty { existingSection }
+                inputSection
+                submitSection
+            }
+            .formStyle(.grouped)
+            .navigationTitle("Submit to SkipDB")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var episodeSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(episodeTitle).font(.headline)
+                if let season, let episode {
+                    Text("Season \(season) · Episode \(episode)")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                Text(imdbId).font(.caption.monospaced()).foregroundStyle(.tertiary)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private var existingSection: some View {
+        Section("Existing segments — tap to correct") {
+            ForEach(existingSegments) { seg in
+                Button {
+                    selectedType = seg.skipDBType
+                    startSec = seg.startSec
+                    endSec = seg.endSec
+                    submitResult = nil
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(seg.label).foregroundStyle(.primary)
+                            Text("\(formatTime(seg.startSec)) → \(formatTime(seg.endSec))")
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Image(systemName: "pencil").foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var inputSection: some View {
+        Section {
+            Picker("Type", selection: $selectedType) {
+                ForEach(SegmentType.allCases) { t in
+                    Text(t.label).tag(t)
+                }
+            }
+            timeRow("Start", seconds: $startSec)
+            timeRow("End", seconds: $endSec)
+            if durationSec > 0 {
+                LabeledContent("Stream duration") {
+                    Text(formatTime(durationSec))
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Segment times (seconds)")
+        } footer: {
+            Text("Scrub to the right position in the player before opening this sheet to pre-fill the start time.")
+        }
+    }
+
+    private var submitSection: some View {
+        Section {
+            Button {
+                Task { await doSubmit() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if submitting {
+                        ProgressView().controlSize(.small)
+                        Text("Submitting…")
+                    } else {
+                        Text("Submit segment")
+                    }
+                    Spacer()
+                }
+            }
+            .disabled(submitting || startSec >= endSec)
+
+            if let result = submitResult {
+                switch result {
+                case .success:
+                    Label("Submitted — thank you!", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                case .failure(let msg):
+                    Label(msg, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                }
+            }
+        } footer: {
+            Text("Submissions are reviewed before going live. See skipdb.tv/terms.")
+        }
+    }
+
+    // MARK: - Time field
+
+    @ViewBuilder private func timeRow(_ label: String, seconds: Binding<Double>) -> some View {
+        LabeledContent(label) {
+            HStack(spacing: 8) {
+                TextField("sec", value: seconds, format: .number.precision(.fractionLength(1)))
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 72)
+                    #if os(iOS)
+                    .keyboardType(.decimalPad)
+                    #endif
+                Text(formatTime(seconds.wrappedValue))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, alignment: .trailing)
+            }
+        }
+    }
+
+    // MARK: - Submit
+
+    private func doSubmit() async {
+        submitting = true
+        submitResult = nil
+        let req = SkipDBClient.SubmitRequest(
+            imdb_id: imdbId,
+            season: season,
+            episode: episode,
+            segment_type: selectedType.rawValue,
+            start_ms: Int(startSec * 1000),
+            end_ms: Int(endSec * 1000),
+            duration_ms: durationSec > 0 ? Int(durationSec * 1000) : nil
+        )
+        do {
+            try await SkipDBClient.submit(req)
+            await SkipDBClient.invalidateCache(imdbId: imdbId, season: season,
+                                               episode: episode, durationSeconds: durationSec)
+            submitResult = .success
+            onSubmitted()
+        } catch {
+            submitResult = .failure(error.localizedDescription)
+        }
+        submitting = false
+    }
+
+    // MARK: - Helpers
+
+    private func formatTime(_ sec: Double) -> String {
+        let s = max(0, Int(sec))
+        return String(format: "%d:%02d", s / 60, s % 60)
+    }
+}
+
+/// A resolved segment surfaced to the submit view so the user can tap to correct it.
+struct SkipDBSegmentItem: Identifiable {
+    let id: String
+    let label: String
+    let skipDBType: SkipDBSubmitView.SegmentType
+    let startSec: Double
+    let endSec: Double
+}


### PR DESCRIPTION
## What and why

<!-- One or two sentences. Link the issue if one exists. -->

- Add api key entry for skipdb.tv
- Add UI for submission for skip segments on mac/iphone

There are probably some UI improvements to be made, or an explanation modal needed to explain how it works.

Currently you click the button in the top right to activate the submission (otherwise it's hidden and UI looks as it did before). The button is also hidden until you add an API key.

You then get the UI with the following actions:
- Type selection (`intro`, `outro/credits`, `preview`, `recap`)
- Skip chapter buttons - useful as sometimes the intro start, end or both are marked by a chapter
- Two groups to control the position for the start/end
  - Move playhead to start/end
  - Set segment position time to current playhead time
  - Add/remove buttons for 0.5s or 0.1s
- Preview button (plays 2 seconds before your segments, skips the selected segment then resumes after to test it works
- Submit button

## Screenshots

<img width="1266" height="811" alt="image" src="https://github.com/user-attachments/assets/26c0daa0-423c-4460-9b8d-e230b492f40a" />


## Checks

- [x] Builds for tvOS (the CI run on this PR uses GitHub's runner SDK, which lags the newest Xcode)
- [ ] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md)
- [x] Screenshots attached for UI changes
