### PR TITLE
fix(tvos): pause-crash jetsam relief, reliable watch progress, smooth post-seek audio

### DIFF
--- a/app/Sources/Player/AVPlayerEngine.swift
+++ b/app/Sources/Player/AVPlayerEngine.swift
@@ -584,7 +584,30 @@ final class AVPlayerEngineController: NSObject, PlayerEngine {
                                                name: .AVPlayerItemDidPlayToEndTime, object: item)
         NotificationCenter.default.addObserver(self, selector: #selector(failedToEnd(_:)),
                                                name: .AVPlayerItemFailedToPlayToEndTime, object: item)
+        #if canImport(UIKit)
+        // Jetsam relief (mirrors MPVMetalViewController.shedForMemoryPressure): a paused AVPlayer keeps
+        // filling its forward buffer at its own discretion, and a 4K / DV-remux HLS stream buffers
+        // hundreds of MB — on tvOS the pause also lets the screensaver (its own 4K pipeline) start on
+        // top, and jetsam reaps this app. The memory warning is the system's last call before that;
+        // respond by capping the item's forward buffer so AVFoundation trims instead of being killed.
+        // Registered per-load because teardownObservers() drops every observer on this object.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMemoryWarningNote),
+                                               name: UIApplication.didReceiveMemoryWarningNotification,
+                                               object: nil)
+        #endif
     }
+
+    #if canImport(UIKit)
+    /// System memory warning: cap the current item's forward buffer (default 0 = "system decides", which
+    /// on a high-bitrate stream is far too generous for a jetsam-bound app). 30s at even remux bitrates
+    /// is a modest, survivable footprint, and AVFoundation releases already-buffered media beyond the new
+    /// preference. Sticky for the rest of this item; the next loadFile mints a fresh item with defaults.
+    @objc private func handleMemoryWarningNote() {
+        guard let item, item.preferredForwardBufferDuration != 30 else { return }
+        item.preferredForwardBufferDuration = 30
+        DiagnosticsLog.log("avplayer", "memory warning: preferredForwardBufferDuration capped to 30s")
+    }
+    #endif
 
     private func handleStatus(_ item: AVPlayerItem) {
         switch item.status {

--- a/app/Sources/Player/MPVMetalViewController.swift
+++ b/app/Sources/Player/MPVMetalViewController.swift
@@ -66,6 +66,17 @@ final class MPVMetalViewController: PlatformViewController {
     var loopPlayback = false
     private let mpvLog = Logger(subsystem: "com.stremiox.app", category: "mpv")
     private var configuredLiveMode = false
+    /// The forward-cache cap (`demuxer-max-bytes`, option-string form) loadFile applied for the CURRENT
+    /// file, so the paused-cache clamp can restore it on resume. nil until the first load.
+    private var activeReadAheadCap: String?
+    /// Pending "still paused after the grace period" cache clamp; cancelled on resume / new load / stop.
+    private var pausedCacheClampWork: DispatchWorkItem?
+    /// True while the paused clamp holds `demuxer-max-bytes` at the small floor (restored on resume).
+    private var pausedCacheClamped = false
+    /// True once a system memory warning forced the cache floor for the REST of this file — a resume must
+    /// not re-raise the cap, because the pressure that fired the warning is usually still there. Reset on
+    /// the next loadFile (a new file starts with its buffers freed and gets its normal budget back).
+    private var memoryCacheClamped = false
     /// The dynamic range currently applied to the output chain (mpv transfer curve, Metal layer
     /// colorspace, and on tvOS the display mode), or nil = "unknown, force a fresh apply". Reset to nil on
     /// every file load and teardown so the FIRST re-evaluation of a new file always applies (the guard
@@ -113,7 +124,17 @@ final class MPVMetalViewController: PlatformViewController {
         #endif
 
         setupMpv()
-        
+
+        #if canImport(UIKit)
+        // Jetsam relief: the system memory warning is the last call before tvOS/iOS kills the app. mpv's
+        // demuxer cache is by far the largest shedable allocation in this process, so respond by clamping
+        // it (see shedForMemoryPressure). Selector-based observer: stop() removes it, and NotificationCenter
+        // auto-unregisters deallocated selector observers as the safety net.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMemoryWarningNote),
+                                               name: UIApplication.didReceiveMemoryWarningNotification,
+                                               object: nil)
+        #endif
+
         if let url = playUrl {
             loadFile(url, headers: playHeaders, live: playUrlLive, audioSidecar: playAudioSidecarURL)
         }
@@ -470,6 +491,26 @@ final class MPVMetalViewController: PlatformViewController {
             mpvLog.log("disk cache armed at \(cacheDir, privacy: .public), budget \(DiskCacheSetting.resolvedMaxBytes(), privacy: .public) bytes")
         }
 
+#if os(tvOS)
+        // Post-seek/track-change smoothing for the tvOS avfoundation AO. Every scrub commit empties the
+        // forward cache and every audio/subtitle track change triggers a demuxer refresh-seek that
+        // discards + re-reads it; playback then resumed instantly on a near-empty cache while the refill
+        // burst saturated the network + demuxer + decoder — so the audio output underran repeatedly,
+        // heard as several seconds of crackly/distorted audio with video lagging until the cache caught
+        // up. The avfoundation AO is also known upstream to drop 30+ frames each time it resumes from an
+        // underrun (mpv-player/mpv#16346), which compounds the visible lag. `cache-pause-initial` holds
+        // playback in the normal buffering state after every start/seek until `cache-pause-wait` seconds
+        // are cached, so playback resumes ONCE, cleanly, instead of stuttering through the refill; the
+        // deeper `audio-buffer` gives the AO slack to ride out the burst's CPU spikes without
+        // underrunning. tvOS-only: iOS/macOS ride the audiounit/coreaudio AOs and don't show this. The
+        // muted hero-preview instance keeps mpv defaults so its ambient clip still starts instantly.
+        if !startMuted {
+            checkError(mpv_set_option_string(mpv, "cache-pause-initial", "yes"))
+            checkError(mpv_set_option_string(mpv, "cache-pause-wait", "2"))
+            checkError(mpv_set_option_string(mpv, "audio-buffer", "0.5"))
+        }
+#endif
+
         // HLS: pick the HIGHEST-bandwidth variant of an adaptive master playlist. mpv's documented
         // default is already `max`, but add-ons that serve a single adaptive master (e.g. KhmerHub's
         // OK.ru streams) were starting at the lowest rendition — the "144p instead of 720p" report —
@@ -721,6 +762,7 @@ final class MPVMetalViewController: PlatformViewController {
     /// destruction is serialized onto the event queue so it can't race `readEvents`.
     func stop() {
         NotificationCenter.default.removeObserver(self)
+        pausedCacheClampWork?.cancel(); pausedCacheClampWork = nil
 #if os(tvOS)
         // Hand the TV back its default display mode; the view can already be
         // detached here, so HDRDisplayMode falls back to the app's window.
@@ -903,6 +945,7 @@ final class MPVMetalViewController: PlatformViewController {
         // what the device survives. demuxer-max-bytes is a hard byte cap, so it bounds RAM regardless of
         // bitrate or whether cache-on-disk offloads. (A LOCAL torrent buffers into the embedded server's
         // own disk cache, and live owns its tight buffers, so those keep the RAM-safe read-ahead above.)
+        let appliedCap: String
         if DiskCacheSetting.diskCacheEnabled, !live, !isLocalStream {
             // DEVICE-SOAK ITEM: the prior flat 256 MiB ceiling masked the Settings slider and starved the
             // read-ahead to ~25-30s on debrid (the owner had 120-200s before). The ATV 4K (4 GB + memory
@@ -924,10 +967,18 @@ final class MPVMetalViewController: PlatformViewController {
             #endif
             let ramCeiling = Int64(RemoteConfig.snapshot.readAheadDebridCeilingBytes(reduced: PerformanceMode.reduced, isMac: isMac))
             let applied = min(DiskCacheSetting.resolvedMaxBytes(), ramCeiling)
-            mpv_set_property_string(mpv, "demuxer-max-bytes", String(applied))
+            appliedCap = String(applied)
         } else {
-            mpv_set_property_string(mpv, "demuxer-max-bytes", readAhead)
+            appliedCap = readAhead
         }
+        mpv_set_property_string(mpv, "demuxer-max-bytes", appliedCap)
+        activeReadAheadCap = appliedCap
+        // New file: the old file's buffers are freed by the load, so clear any paused/memory cache clamp
+        // from the previous file and start this one on its normal budget (recorded above for the paused
+        // clamp to restore on resume).
+        pausedCacheClampWork?.cancel(); pausedCacheClampWork = nil
+        pausedCacheClamped = false
+        memoryCacheClamped = false
 
         if !options.isEmpty {
             args.append(options.joined(separator: ","))
@@ -965,6 +1016,73 @@ final class MPVMetalViewController: PlatformViewController {
     func togglePause() {
         getFlag(MPVProperty.pause) ? play() : pause()
     }
+
+    #if canImport(UIKit)
+    // MARK: - Jetsam relief: paused-cache clamp + memory-warning shedding (iOS/tvOS)
+    //
+    // mpv keeps FILLING the forward demuxer cache to `demuxer-max-bytes` while PAUSED, so a viewer who
+    // starts a stream and immediately pauses parks the app at its peak cache footprint (256 MiB default
+    // remote; up to 768 MiB with the Streaming-cache setting) for the whole pause. On tvOS the pause also
+    // re-enables the idle timer, so a few minutes in the SCREENSAVER (its own 4K video pipeline) starts on
+    // top — exactly when this app is at its fattest — and jetsam reaps the app: the "start a video, pause
+    // for some minutes, app is suddenly gone" crash. Two defenses, both engine-local and reset per load:
+    //  1. Paused clamp: after `pausedClampGraceSeconds` of continuous pause, drop the forward cap to a
+    //     small floor and FREE the already-buffered read-ahead (`drop-buffers` — shrinking the cap alone
+    //     stops growth but releases nothing). Restored on resume; a healthy link refills in seconds.
+    //  2. Memory warning: the system's last call before jetsam. Clamp to the floor immediately and keep
+    //     it there for the rest of this file; playback survives fine on the small rolling buffer.
+
+    private static let pausedClampGraceSeconds: TimeInterval = 60
+    private static let clampedCacheCap = "48MiB"
+
+    /// Main-thread mirror of mpv's pause property (posted from the event drain). Arms the paused clamp
+    /// after the grace period, and restores the per-file cache cap on resume.
+    private func pausedStateChanged(_ paused: Bool) {
+        pausedCacheClampWork?.cancel(); pausedCacheClampWork = nil
+        if paused {
+            // Live keeps its own tight buffers, and once a memory warning clamped this file the floor is
+            // already in force; nothing to arm in either case.
+            guard mpv != nil, !configuredLiveMode, !memoryCacheClamped, !pausedCacheClamped else { return }
+            let work = DispatchWorkItem { [weak self] in self?.applyPausedCacheClamp() }
+            pausedCacheClampWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.pausedClampGraceSeconds, execute: work)
+        } else if pausedCacheClamped {
+            pausedCacheClamped = false
+            guard mpv != nil, !memoryCacheClamped, let cap = activeReadAheadCap else { return }
+            setString("demuxer-max-bytes", cap)
+            mpvLog.log("resumed: paused cache clamp released, demuxer-max-bytes back to \(cap, privacy: .public)")
+        }
+    }
+
+    private func applyPausedCacheClamp() {
+        guard mpv != nil, !pausedCacheClamped, !memoryCacheClamped else { return }
+        guard getFlag(MPVProperty.pause) else { return }   // belt-and-suspenders; resume cancels the work item
+        pausedCacheClamped = true
+        setString("demuxer-max-bytes", Self.clampedCacheCap)
+        // Freeing is the point. Dropping re-reads from the playhead on resume, which needs a seekable
+        // stream (every debrid/direct-HTTP source is); a rare non-seekable stream keeps its buffers.
+        if getFlag(MPVProperty.seekable) { command("drop-buffers") }
+        mpvLog.log("paused \(Int(Self.pausedClampGraceSeconds), privacy: .public)s: demuxer cache clamped to \(Self.clampedCacheCap, privacy: .public) until resume")
+        DiagnosticsLog.log("player", "long pause: mpv read-ahead clamped to \(Self.clampedCacheCap) until resume")
+    }
+
+    /// System memory warning (registered in viewDidLoad). Posted on the main thread; re-dispatch is a
+    /// cheap guarantee in case a future SDK posts it elsewhere.
+    @objc private func handleMemoryWarningNote() {
+        DispatchQueue.main.async { [weak self] in self?.shedForMemoryPressure() }
+    }
+
+    private func shedForMemoryPressure() {
+        guard mpv != nil, !memoryCacheClamped else { return }
+        memoryCacheClamped = true
+        pausedCacheClampWork?.cancel(); pausedCacheClampWork = nil
+        setString("demuxer-max-bytes", Self.clampedCacheCap)
+        setString("demuxer-max-back-bytes", "8MiB")
+        if getFlag(MPVProperty.seekable) { command("drop-buffers") }
+        mpvLog.log("memory warning: demuxer cache clamped to \(Self.clampedCacheCap, privacy: .public) for the rest of this file")
+        DiagnosticsLog.log("player", "memory warning: mpv cache clamped to \(Self.clampedCacheCap) + buffers dropped")
+    }
+    #endif
 
     private func updateCapturePipeline() {
         guard let device = metalLayer.device else { return }
@@ -1651,6 +1769,11 @@ final class MPVMetalViewController: PlatformViewController {
                             VXProbeState.shared.setPlayer(state: paused ? "paused" : "playing")
                             VXProbe.log("player", paused ? "paused" : "playing")
                             self.emit(propertyName, paused)
+                            #if canImport(UIKit)
+                            // Jetsam relief: arm/release the paused-cache clamp (main thread; this drain
+                            // runs on the mpv event queue).
+                            DispatchQueue.main.async { [weak self] in self?.pausedStateChanged(paused) }
+                            #endif
                         case MPVProperty.trackList:
                             self.emit(propertyName, nil)
                         default: break

--- a/app/Sources/Player/MPVMetalViewController.swift
+++ b/app/Sources/Player/MPVMetalViewController.swift
@@ -1059,11 +1059,27 @@ final class MPVMetalViewController: PlatformViewController {
         guard getFlag(MPVProperty.pause) else { return }   // belt-and-suspenders; resume cancels the work item
         pausedCacheClamped = true
         setString("demuxer-max-bytes", Self.clampedCacheCap)
-        // Freeing is the point. Dropping re-reads from the playhead on resume, which needs a seekable
-        // stream (every debrid/direct-HTTP source is); a rare non-seekable stream keeps its buffers.
-        if getFlag(MPVProperty.seekable) { command("drop-buffers") }
+        flushDemuxerCachePreservingPosition()
         mpvLog.log("paused \(Int(Self.pausedClampGraceSeconds), privacy: .public)s: demuxer cache clamped to \(Self.clampedCacheCap, privacy: .public) until resume")
         DiagnosticsLog.log("player", "long pause: mpv read-ahead clamped to \(Self.clampedCacheCap) until resume")
+    }
+
+    /// Free the demuxer cache WITHOUT moving the play head. `drop-buffers` alone is the wrong tool on a
+    /// seekable stream: it discards the cached packets but leaves the demuxer's READ position at the
+    /// buffered edge (it exists for live streams, where skipping to the edge is the point), so playback
+    /// silently continued from minutes ahead of where the viewer paused — the "jumps forward after a
+    /// minute of pause" regression reported on the first cut of this clamp. Drop, then EXACT-seek back
+    /// to the recorded play head: the RAM is freed and demuxing re-anchors at the right byte offset,
+    /// with the refill bounded by the (already lowered) cap. The exact flag re-decodes to the same
+    /// frame, so the paused picture does not visibly move. Seekable streams only — a non-seekable
+    /// stream cannot re-read, so it keeps its buffers rather than corrupting playback; and a not-yet
+    /// known position (time-pos <= 0) skips too rather than risk re-anchoring at 0.
+    private func flushDemuxerCachePreservingPosition() {
+        guard getFlag(MPVProperty.seekable) else { return }
+        let pos = getDouble(MPVProperty.timePos)
+        guard pos > 0 else { return }
+        command("drop-buffers")
+        command("seek", args: [String(format: "%.3f", pos), "absolute+exact"])
     }
 
     /// System memory warning (registered in viewDidLoad). Posted on the main thread; re-dispatch is a
@@ -1078,7 +1094,7 @@ final class MPVMetalViewController: PlatformViewController {
         pausedCacheClampWork?.cancel(); pausedCacheClampWork = nil
         setString("demuxer-max-bytes", Self.clampedCacheCap)
         setString("demuxer-max-back-bytes", "8MiB")
-        if getFlag(MPVProperty.seekable) { command("drop-buffers") }
+        flushDemuxerCachePreservingPosition()   // NOT bare drop-buffers: that moves the play head (see above)
         mpvLog.log("memory warning: demuxer cache clamped to \(Self.clampedCacheCap, privacy: .public) for the rest of this file")
         DiagnosticsLog.log("player", "memory warning: mpv cache clamped to \(Self.clampedCacheCap) + buffers dropped")
     }

--- a/app/Sources/PlayerScreen.swift
+++ b/app/Sources/PlayerScreen.swift
@@ -791,6 +791,15 @@ struct PlayerScreen: View {
                 }
                 if !scrubbing {
                     currentTime = d
+                    // Durationless-stream fallback (mirrors TVPlayerView): many debrid direct-HTTP MKVs
+                    // never DELIVER mpv's `duration` EVENT, yet the property reads fine — and the resume
+                    // seek, the ~5s progress pushes, and watched-at-90% all key off `duration > 0`, so
+                    // those streams never saved a watch position. Poll the engine each (coalesced) tick
+                    // until a real value lands and route it through the same handling as the event.
+                    if duration <= 0, !effectivelyLive,
+                       let engineDur = coordinator.player?.mediaDurationSeconds(), engineDur.isFinite, engineDur > 0 {
+                        handleProperty(MPVProperty.duration, engineDur)
+                    }
                     #if !os(tvOS)
                     if skipDBPreviewing, d >= skipDBEditStart {
                         skipDBPreviewing = false

--- a/app/SourcesShared/CoreBridge.swift
+++ b/app/SourcesShared/CoreBridge.swift
@@ -508,6 +508,19 @@ final class CoreBridge: ObservableObject {
         dispatchCtx(["action": "SyncLibraryWithAPI"])
     }
 
+    /// Reconcile the engine's library copy with api.strem.io NOW. The tvOS player writes watch progress
+    /// directly to the account API (StremioAccount.saveProgress), which the engine cannot see until its
+    /// next library sync — and nothing scheduled one after playback, so the Home dashboard's Continue
+    /// Watching card kept the pre-playback timestamp (and fed a stale resume) until a detail-page load
+    /// happened to trigger a sync (the "have to long-press → Details to refresh the timestamp" report).
+    /// Called by the player's exit path AFTER its final save has landed on the API, so the pull can
+    /// never race the write it exists to fetch. The sync re-emits `continue_watching_preview`, which
+    /// republishes the rail. No-op for overlay profiles (their history never touches the engine).
+    func syncLibraryNow() {
+        guard ProfileStore.shared.activeUsesEngineHistory else { return }
+        dispatchCtx(["action": "SyncLibraryWithAPI"])
+    }
+
     /// Seed the engine right after a fresh sign-in (LoginView wrote the authKey to the active
     /// profile's slot). When the engine still holds ANOTHER profile's session, this routes through
     /// the switch path instead, because bootstrapAuth would see "logged in" and keep the old session.

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -310,10 +310,27 @@ struct SettingsView: View {
             choiceRow(String(localized: "Video upscaling"), VideoUpscaling.allCases.map { ($0.rawValue, $0.label) }, selection: $videoUpscaling)
             Text(VideoUpscaling(rawValue: videoUpscaling)?.detail ?? "")
                 .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
+            // Streaming cache, honest tvOS presentation. On this MPVKit build the buffer is HELD IN
+            // MEMORY (cache-on-disk does not reliably offload; see MPVMetalViewController.loadFile), and
+            // the applied budget is clamped to the device-safe RAM ceiling (~768 MB on Apple TV 4K) no
+            // matter how large a tier is chosen. The old 2/5/10/20 GB / Unlimited tiers therefore all
+            // resolved to the SAME cap while implying a big disk cache — the trap that had a viewer
+            // running "2 GB" for weeks without knowing they had tripled their memory exposure. tvOS now
+            // offers the honest binary: Off, or the larger memory buffer at its real ceiling (label
+            // computed from the live RemoteConfig dial, so a fleet re-tune re-labels itself). Picking On
+            // stores the same 2 GB value the old default tier wrote, so the engine path, sync payloads,
+            // and other platforms are completely unchanged; a bigger tier synced from another device
+            // still shows as On here. On the Apple TV HD the ceiling (~128 MB) barely exceeds the
+            // always-on standard buffer, so the row is disabled with the reason in the footer instead of
+            // offering a near-no-op that only adds memory pressure. Presentation-only change:
+            // DiskCacheSetting and the player path are untouched.
             choiceRow(String(localized: "Streaming cache"),
-                      DiskCacheSetting.pickerOptions.map { (String($0.id), $0.label) },
-                      selection: Binding(get: { String(diskCacheBytes) },
-                                         set: { diskCacheBytes = Int($0) ?? Int(DiskCacheSetting.defaultBytes) }))
+                      [("0", String(localized: "Off")),
+                       ("on", String(localized: "On (up to \(streamingCacheCeilingMB) MB of memory)"))],
+                      selection: Binding(get: { diskCacheBytes == 0 ? "0" : "on" },
+                                         set: { diskCacheBytes = ($0 == "on") ? Int(DiskCacheSetting.defaultBytes) : 0 }))
+                .disabled(PerformanceMode.isConstrainedDevice)
+                .opacity(PerformanceMode.isConstrainedDevice ? 0.4 : 1)
             Text(diskCacheFooter)
                 .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
             choiceRow(String(localized: "Player engine"), PlayerEngineRouter.Override.allCases.map { ($0.rawValue, $0.label) }, selection: $playerEngine)
@@ -439,18 +456,31 @@ struct SettingsView: View {
         [("", "Built-in player")] + ExternalPlayers.menu().map { ($0.id, $0.name) }
     }
 
-    /// Explains the streaming cache and shows live on-disk usage when on. On the Apple TV HD the cache
-    /// is additionally capped tight; Unlimited is always bounded to half of free storage and cleared
-    /// when a title finishes, so it never fills the device.
+    /// The REAL ceiling (in MB) the player will apply to this buffer on this device — the same
+    /// RemoteConfig dial `MPVMetalViewController.loadFile` clamps `demuxer-max-bytes` with (~768 MB on
+    /// Apple TV 4K, ~128 MB in reduced mode). Shown in the On chip + footer so the setting promises
+    /// exactly what it delivers. Uses `PerformanceMode.reduced` (not the hardware test) because that is
+    /// what the engine applies, so a forced reduced mode re-labels honestly too.
+    private var streamingCacheCeilingMB: Int {
+        RemoteConfig.snapshot.readAheadDebridCeilingBytes(reduced: PerformanceMode.reduced, isMac: false) / (1024 * 1024)
+    }
+
+    /// Explains the streaming cache honestly for tvOS: the buffer is held in MEMORY on this build (the
+    /// on-disk offload does not engage; the old copy promised a disk cache), it is capped at the
+    /// device-safe ceiling, and a larger buffer trades seek-ahead runway for memory-pressure risk. On
+    /// the Apple TV HD (row disabled) it explains why the option is unavailable there.
     private var diskCacheFooter: String {
-        let base = String(localized: "A bigger streaming cache buffers more video on disk so you can seek minutes ahead without re-buffering. Unlimited is still capped to half your free storage and the cache clears when a title finishes, so it never fills your Apple TV.")
+        if PerformanceMode.isConstrainedDevice {
+            return String(localized: "Not available on this Apple TV: this model would cap the buffer at about \(streamingCacheCeilingMB) MB, barely above the standard buffer that is always active, while adding memory pressure on its limited RAM.")
+        }
+        let base = String(localized: "Buffers more video ahead of the play head so you can seek further without re-buffering. On Apple TV this buffer is held in memory, capped at about \(streamingCacheCeilingMB) MB; a larger buffer can increase the chance tvOS closes the app under memory pressure. It clears when a title finishes.")
         guard diskCacheBytes != 0 else { return base }
-        // currentUsageBytes sums the on-disk mpv-cache dir, which stays EMPTY on this MPVKit build (the
-        // buffer is RAM-resident, not offloaded to disk), so it always read "0 KB" and looked broken. Show
-        // the real RAM-bounded budget the player will actually use instead (floored at 64 MiB, clamped to
-        // the device-safe ceiling), which is an honest non-zero number visible in Settings.
-        let budget = DiskCacheSetting.humanReadable(DiskCacheSetting.resolvedMaxBytes())
-        return base + " " + String(localized: "Cache budget: \(budget).")
+        // Show the budget the player will ACTUALLY apply: the stored choice, bounded by free disk and
+        // the device-safe RAM ceiling above — the same min() the engine computes at load. (The on-disk
+        // usage readout this once was stays retired: the mpv-cache dir is empty on this build.)
+        let applied = min(DiskCacheSetting.resolvedMaxBytes(),
+                          Int64(RemoteConfig.snapshot.readAheadDebridCeilingBytes(reduced: PerformanceMode.reduced, isMac: false)))
+        return base + " " + String(localized: "Active buffer budget: \(DiskCacheSetting.humanReadable(applied)).")
     }
 
     private var effectiveDirectLinksOnly: Bool {

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -391,9 +391,19 @@ struct TVPlayerView: View {
             showInfo = true; selected = .play; scheduleHide(); startLoadTimeout()
             UIApplication.shared.isIdleTimerDisabled = true   // stop the Apple TV screensaver during playback
             if let m = curMeta {
-                if let engineResume = core.engineResumeSeconds(for: m) {
-                    resumeSeconds = engineResume; maybeResume()       // engine library = source of truth
+                if let engineResume = core.engineResumeSeconds(for: m), engineResume > 5 {
+                    resumeSeconds = engineResume; maybeResume()       // engine has a real position: use it
                 } else {
+                    // Engine has no entry — OR answered "start fresh" (0, including its stale-video_id
+                    // mismatch branch). The engine's library copy can lag the account: it hears TimeChanged
+                    // on a throttle and its video_id can be left stale by a watched/unwatched toggle, while
+                    // this device's exit save already put the fresh position on the account. Trusting the
+                    // bare 0 replayed the title from 0:00 and the early exit then SAVED ~0 over the real
+                    // position (the "scrubbed to 06:20, reopened at the beginning, position lost" report).
+                    // Consulting the account here is episode-safe by construction: resumeOffset does its
+                    // own video_id match and returns 0 for a different episode, so the wrong-episode resume
+                    // the engine's 0-answer guards against cannot happen. Overlay profiles keep their own
+                    // private-history path inside resumeOffset, exactly as before.
                     Task { @MainActor in resumeSeconds = await account.resumeOffset(for: m); maybeResume() }
                 }
             } else {

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -266,6 +266,19 @@ struct TVPlayerView: View {
     @State private var scrubStep = 10.0
     @State private var lastScrubAt = 0.0
     @State private var scrubCommit: Task<Void, Never>?
+    /// Seek-in-flight guard: the target of the last user-committed absolute seek (scrub commit, Restart,
+    /// the resume seek), plus when it was issued. While set, incoming timePos ticks that are still FAR
+    /// from the target are ignored instead of overwriting `currentTime`: after a committed seek, mpv can
+    /// keep emitting ticks from the OLD position for seconds (an exact seek on a big remux decodes from
+    /// the keyframe + refills the cache first, and back-and-forth scrubbing queues several seeks), and
+    /// those stale ticks clobbered the freshly committed position — so exiting right after HEAVY
+    /// scrubbing saved a stale spot ("progress stuck at 12:20 after scrubbing far past it"). Cleared as
+    /// soon as a tick lands near the target (the seek settled) or the settle window expires (the seek
+    /// genuinely ended elsewhere — clamped at EOF, failed — so live ticks win again).
+    @State private var inFlightSeekTarget: Double?
+    @State private var inFlightSeekIssuedAt = 0.0
+    private let inFlightSeekSettleWindow = 10.0   // seconds before stale-looking ticks are trusted again
+    private let inFlightSeekSnapRadius = 5.0      // a tick this close to the target means the seek landed
     private let plog = Logger(subsystem: "com.stremiox.app", category: "tvplayer")
 
     private var controlsHidden: Bool { !showInfo && !showOptions && !loadFailed }
@@ -527,6 +540,17 @@ struct TVPlayerView: View {
                     // exactly that content. Fetch at playback start too (key-latched, so at most one real
                     // fetch runs); the duration-event call remains for streams that deliver it first.
                     fetchAddonSubtitles()
+                }
+                // Seek-in-flight guard (see the state declaration): drop stale pre-seek ticks so they
+                // cannot clobber the freshly committed position; everything downstream of a tick
+                // (progress saves, watched-at-90%, skip spans) waits with it.
+                if let target = inFlightSeekTarget {
+                    if abs(d - target) <= inFlightSeekSnapRadius
+                        || Date().timeIntervalSinceReferenceDate - inFlightSeekIssuedAt > inFlightSeekSettleWindow {
+                        inFlightSeekTarget = nil   // settled near the target, or the window expired: trust ticks again
+                    } else {
+                        return
+                    }
                 }
                 currentTime = d
                 // Durationless-stream fallback (the "watch position never saved / no resume on some
@@ -2915,6 +2939,7 @@ struct TVPlayerView: View {
         withAnimation { showOptions = false }
         buffering = true; hasStartedPlaying = false; appliedResume = false
         loadFailed = false; currentTime = 0; duration = 0; bufferedTime = 0; lastSaved = -1; resumeSeconds = nil; appliedAutoTracks = false; autoAddonSubTried = false; appliedVolume = false
+        inFlightSeekTarget = nil   // any pending seek belonged to the PREVIOUS episode; new media ticks are authoritative
         suppressedResumeFloor = nil   // the floor belongs to the PREVIOUS title's suppressed remux resume
         // A new episode's source is a RANKED auto-pick (auto-advance) or an episode-panel pick (the user chose
         // the EPISODE, not the source), never a source-row tap. Clear the explicit flag so a slow/dead episode
@@ -3221,6 +3246,8 @@ struct TVPlayerView: View {
         coordinator.player?.seek(to: r)
         currentTime = r
         lastSaved = r
+        inFlightSeekTarget = r   // same guard as commitScrub: pre-resume ticks near 0 must not clobber the resume point
+        inFlightSeekIssuedAt = Date().timeIntervalSinceReferenceDate
     }
 
     /// Persist the current position to the account library (no-op without a library context). Also a
@@ -3256,6 +3283,8 @@ struct TVPlayerView: View {
         commitScrubIfNeeded()
         coordinator.player?.seek(to: 0)
         currentTime = 0; lastSaved = 0
+        inFlightSeekTarget = 0   // same guard as commitScrub: a stale tick must not undo the restart
+        inFlightSeekIssuedAt = Date().timeIntervalSinceReferenceDate
         flashControls()
     }
 
@@ -3300,6 +3329,8 @@ struct TVPlayerView: View {
         scrubbing = false
         coordinator.player?.seek(to: scrubTarget)
         currentTime = scrubTarget; lastSaved = scrubTarget
+        inFlightSeekTarget = scrubTarget   // stale pre-seek ticks must not clobber this commit
+        inFlightSeekIssuedAt = Date().timeIntervalSinceReferenceDate
         scrubThumbnails.clear()
         flashControls()
     }

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -504,7 +504,18 @@ struct TVPlayerView: View {
             if let b = data as? Bool {
                 isPaused = b
                 UIApplication.shared.isIdleTimerDisabled = !b   // hold the TV awake while playing; let it sleep when paused
-                if b { saveProgress(at: currentTime) }   // persist on pause
+                if b {
+                    saveProgress(at: currentTime)   // persist on pause
+                    // Keep the ENGINE's library copy in step too (same floor rule as the 20s tick).
+                    // The engine previously only heard the throttled tick + the exit flush, so its
+                    // copy could lag far behind the account writes — and any engine-side push (the
+                    // watched/unwatched toggle, a sync) then resurrected that stale position over
+                    // the newer account value (the "unmarked watched, an old scrub position came
+                    // back" report). Engine dispatches are ordered, so this can never race backward.
+                    if !isCurrentLiveStream, suppressedResumeFloor == nil || currentTime >= (suppressedResumeFloor ?? 0) {
+                        core.reportProgress(timeSeconds: currentTime, durationSeconds: duration)
+                    }
+                }
             }
         case MPVProperty.timePos:
             if let d = data as? Double {
@@ -3362,6 +3373,15 @@ struct TVPlayerView: View {
         currentTime = scrubTarget; lastSaved = scrubTarget
         inFlightSeekTarget = scrubTarget   // stale pre-seek ticks must not clobber this commit
         inFlightSeekIssuedAt = Date().timeIntervalSinceReferenceDate
+        // A commit is exactly when the position jumps by minutes, and `lastSaved = scrubTarget` above
+        // suppresses the next throttled tick — so without this the ENGINE's library copy only learned
+        // the new position at the exit flush, and an engine-side push (watched toggle, sync) in between
+        // resurrected the pre-scrub position. Report the committed position immediately; the account
+        // write keeps its pause/20s/exit cadence (network saves are unordered, so fewer is safer there).
+        if !isCurrentLiveStream, duration > 0,
+           suppressedResumeFloor == nil || scrubTarget >= (suppressedResumeFloor ?? 0) {
+            core.reportProgress(timeSeconds: scrubTarget, durationSeconds: duration)
+        }
         scrubThumbnails.clear()
         flashControls()
     }

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -529,6 +529,19 @@ struct TVPlayerView: View {
                     fetchAddonSubtitles()
                 }
                 currentTime = d
+                // Durationless-stream fallback (the "watch position never saved / no resume on some
+                // debrid MKVs" report): many debrid direct-HTTP MKVs never DELIVER mpv's `duration`
+                // EVENT, yet the property itself reads fine (the subtitle-fingerprint path already
+                // relies on that). Everything downstream keys off `duration > 0` — the resume seek,
+                // the ~20s progress saves, watched-at-90%, Up Next — so those streams lost their watch
+                // position entirely and always restarted from 0. Poll the engine each (coalesced) tick
+                // until a real value lands and route it through the same handling as the event; one C
+                // property read at ~2-4 Hz, and it stops the moment duration is known. The AVPlayer
+                // engine returns 0 here (it delivers its duration event reliably), so this is mpv-only.
+                if duration <= 0, !isCurrentLiveStream,
+                   let engineDur = coordinator.player?.mediaDurationSeconds(), engineDur.isFinite, engineDur > 0 {
+                    handleProperty(MPVProperty.duration, engineDur)
+                }
                 updateCurrentSkip(at: d)
                 // Ensure the community key is provisioned off meta.runtime the moment the behind-playback
                 // meta lands (idempotent; no-op once keyed), so capture starts even without a duration event.

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -423,7 +423,7 @@ struct TVPlayerView: View {
             // (first-writer-wins, background, gated; no-op if the community already had a set, or on AVPlayer
             // which captures nothing). Independent of the engine-teardown rules below.
             scrubThumbnails.finishAndUploadIfNeeded(srcHeight: videoHeight)
-            saveProgress(at: currentTime)   // no-op for live
+            saveProgress(at: currentTime, thenSyncEngine: true)   // exit flush: save, THEN pull the engine's library fresh (no-op for live)
             if !isCurrentLiveStream {
                 core.reportProgress(timeSeconds: currentTime, durationSeconds: duration)   // flush final position (never for live)
             }
@@ -3298,7 +3298,14 @@ struct TVPlayerView: View {
     /// Persist the current position to the account library (no-op without a library context). Also a
     /// no-op for live: persisting a live "position" would seed a bogus resume offset / fake Continue
     /// Watching entry the next time the channel opens. Mirrors PlayerScreen's live progress suppression.
-    private func saveProgress(at position: Double) {
+    /// `thenSyncEngine` (the EXIT flush only): after this save LANDS on the account API, ask the engine
+    /// to reconcile its library copy (CoreBridge.syncLibraryNow). The player writes progress straight to
+    /// the API, which the engine cannot see until a library sync — and none ran after playback, so the
+    /// Home dashboard's Continue Watching timestamp (and the resume it feeds) stayed at the pre-playback
+    /// value until a detail-page load happened to sync. Sequenced INSIDE the save task so the pull can
+    /// never race ahead of the write it needs to fetch. Exit-only: the periodic 20s / pause saves must
+    /// not each trigger an API library sync.
+    private func saveProgress(at position: Double, thenSyncEngine: Bool = false) {
         guard !isCurrentLiveStream else { return }
         guard let m = curMeta, duration > 0, position >= 0 else { return }
         // A DV-remux play whose resume seek was suppressed (maybeResume) starts from 0: do not let the
@@ -3309,7 +3316,10 @@ struct TVPlayerView: View {
             suppressedResumeFloor = nil
         }
         let dur = duration
-        Task { await account.saveProgress(for: m, positionSeconds: position, durationSeconds: dur) }
+        Task {
+            await account.saveProgress(for: m, positionSeconds: position, durationSeconds: dur)
+            if thenSyncEngine { await MainActor.run { core.syncLibraryNow() } }
+        }
     }
 
     private func toggle() {

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -279,6 +279,10 @@ struct TVPlayerView: View {
     @State private var inFlightSeekIssuedAt = 0.0
     private let inFlightSeekSettleWindow = 10.0   // seconds before stale-looking ticks are trusted again
     private let inFlightSeekSnapRadius = 5.0      // a tick this close to the target means the seek landed
+    /// Wall-clock when settled playback first ticked inside the last-10% "watched" zone, nil while
+    /// outside it (or while scrubbing). The watched marker requires a few seconds of dwell here, so a
+    /// scrub commit that merely LANDS past 90% can no longer mark the episode watched on its first tick.
+    @State private var watchedZoneSince: Double?
     private let plog = Logger(subsystem: "com.stremiox.app", category: "tvplayer")
 
     private var controlsHidden: Bool { !showInfo && !showOptions && !loadFailed }
@@ -582,9 +586,28 @@ struct TVPlayerView: View {
                         core.reportProgress(timeSeconds: d, durationSeconds: duration)   // live -> engine
                     }
                 }
-                if !markedWatched, duration > 0, d / duration >= 0.9, let m = curMeta {
-                    markedWatched = true            // ~90% in → flip the watched marker live
-                    core.markPlaybackWatched(m)
+                // ~90% in → flip the watched marker live. DWELL-GATED: a single tick past 90% is not
+                // proof of watching — a scrub commit that lands there (easy mid back-and-forth, since a
+                // held press ramps to 75s steps) used to mark the episode watched instantly, and the mark
+                // stuck even when the viewer scrubbed straight back and exited early: Continue Watching
+                // dropped the episode and the selector moved on (the same wipe as the EOF overshoot).
+                // Require a few seconds of SETTLED playback in the zone (not scrubbing, ticks flowing)
+                // before marking; leaving the zone re-arms. A natural finish is unaffected: the last 10%
+                // of any episode dwarfs the dwell, and a true EOF still marks watched via endFileEof.
+                if !markedWatched, duration > 0, d / duration >= 0.9 {
+                    let now = Date().timeIntervalSinceReferenceDate
+                    if scrubbing {
+                        watchedZoneSince = nil          // previewing, not watching: reset the dwell
+                    } else if let since = watchedZoneSince {
+                        if now - since >= 5, let m = curMeta {
+                            markedWatched = true
+                            core.markPlaybackWatched(m)
+                        }
+                    } else {
+                        watchedZoneSince = now          // entered the zone: start the dwell clock
+                    }
+                } else {
+                    watchedZoneSince = nil              // below the zone (scrubbed back out): re-arm
                 }
                 // ~60s in → the user is really watching this: auto-add to the Library (D8) + send the anon
                 // fleet watch ping (D9), once per playback. Idempotent + gated (D8 setting + per-profile dedup;
@@ -2940,6 +2963,7 @@ struct TVPlayerView: View {
         buffering = true; hasStartedPlaying = false; appliedResume = false
         loadFailed = false; currentTime = 0; duration = 0; bufferedTime = 0; lastSaved = -1; resumeSeconds = nil; appliedAutoTracks = false; autoAddonSubTried = false; appliedVolume = false
         inFlightSeekTarget = nil   // any pending seek belonged to the PREVIOUS episode; new media ticks are authoritative
+        watchedZoneSince = nil     // the watched-zone dwell belonged to the previous episode too
         suppressedResumeFloor = nil   // the floor belongs to the PREVIOUS title's suppressed remux resume
         // A new episode's source is a RANKED auto-pick (auto-advance) or an episode-panel pick (the user chose
         // the EPISODE, not the source), never a source-row tap. Clear the explicit flag so a slow/dead episode
@@ -3308,7 +3332,14 @@ struct TVPlayerView: View {
             scrubStep = 10                               // paused between presses → back to fine steps
         }
         lastScrubAt = now
-        scrubTarget = min(duration, max(0, scrubTarget + Double(dir) * scrubStep))
+        // Clamp an overshoot a few seconds BEFORE the end, never AT it. The accelerating ramp reaches the
+        // clamp in a few held presses, and a commit at the exact duration seeks straight into end-of-file:
+        // mpv fires EOF, the player treats that as "episode finished" — marks it watched and auto-advances
+        // — and the viewer's real progress is wiped (the "scrubbed fast, exited, progress and episode
+        // selection gone" report). Landing 5s short shows the actual ending and lets natural playback
+        // reach EOF with all the finished semantics intact; a short clip keeps the plain full-range clamp.
+        let scrubCeiling = duration > 30 ? duration - 5 : duration
+        scrubTarget = min(scrubCeiling, max(0, scrubTarget + Double(dir) * scrubStep))
         scrubThumbnails.show(time: scrubTarget)
         flashControls()
         scheduleScrubCommit()


### PR DESCRIPTION
## What and why

Started from one field report on an Apple TV 4K (Lite build, 0.3.12, Streaming cache set to 2 GB): the app sometimes crashed when a video was started and immediately paused for a few minutes, watch progress was sometimes lost (resume jumped to 0:00), and after heavy scrubbing or audio/subtitle changes the audio was distorted with playback lagging for a few seconds. Each fix below was tested on the real device by the reporter, and the later fixes came out of that report → test → refine loop (the testing peeled several distinct bugs off what looked like one symptom). Every fix states its root cause; nothing here is speculative tuning.

### 1. Crash when pausing shortly after starting a video — `61ea41a`, `2d2279e`

**Root cause:** mpv keeps filling the forward demuxer cache to `demuxer-max-bytes` while PAUSED (256 MiB default remote; up to the 768 MiB ceiling with the Streaming-cache setting), so a pause right after start parks the app at its peak footprint. On tvOS the pause also re-enables the idle timer, so minutes later the screensaver's own 4K pipeline starts on top — exactly when the app is fattest — and jetsam reaps it. The app also had **no memory-warning handling anywhere**.

**Fix (engine-local, reset per load):**
- After 60s of continuous pause, clamp the forward cap to 48 MiB and free the buffered read-ahead; restored on resume (a healthy link refills in seconds). Skipped for live.
- On the system memory warning, clamp immediately for the rest of the file (mpv), and cap `preferredForwardBufferDuration` on the AVPlayer lane. Both log to DiagnosticsLog so any remaining crash is traceable from an export.
- `2d2279e` fixes the first cut of the freeing: bare `drop-buffers` leaves the demuxer read position at the buffered edge (it exists for live streams), which silently jumped playback minutes ahead one minute into a pause. Both shed paths now drop and **exact-seek back to the recorded play head** (skipped for non-seekable streams / unknown position).

**Verified on device:** pause-at-start survives long pauses incl. screensaver; picture no longer moves at the 60s mark; buffered band visibly shrinks (RAM actually freed); short pauses unaffected.

### 2. Watch progress never saved on some streams — `61ea41a`

**Root cause:** many debrid direct-HTTP MKVs never deliver mpv's `duration` EVENT, yet the property reads fine (the subtitle-fingerprint path already relies on that). The resume seek, the periodic progress saves, watched-at-90%, and Up Next all gate on `duration > 0`, so exactly those streams never saved a position and always restarted from 0:00.

**Fix:** poll the engine's duration on the (coalesced) timePos tick until a real value lands and route it through the same handling as the event. Applied to `TVPlayerView` and, same pattern, `PlayerScreen` (iOS/Mac).

### 3. Distorted audio + lag after scrubbing / track changes (tvOS) — `61ea41a`

**Root cause:** every scrub commit empties the forward cache and every audio/subtitle track change refresh-seeks it; playback resumed instantly on a near-empty cache while the refill burst saturated the network + decoder, so the avfoundation AO underran repeatedly — and it is known upstream to drop 30+ frames per underrun resume (mpv-player/mpv#16346).

**Fix (tvOS only; iOS/macOS ride audiounit/coreaudio):** `cache-pause-initial=yes` + `cache-pause-wait=2` so playback resumes once, cleanly, after a short honest buffer instead of stuttering through the refill, plus `audio-buffer=0.5` for AO slack. The muted hero-preview instance keeps mpv defaults.

**Verified on device:** post-seek/track-change distortion gone; brief spinner instead.

### 4. Heavy scrubbing then exit saved a stale position — `62bedd4`

**Root cause:** `commitScrub` sets `currentTime` optimistically, but mpv keeps emitting timePos ticks from the OLD position until the (queued, exact) seeks land — seconds on a big remux — and those stale ticks clobbered the committed value; exiting inside the window saved the stale spot. A single scrub settles before you can exit, which is why it always looked fine.

**Fix:** seek-in-flight guard. The last committed absolute seek (scrub commit / Restart / the resume seek) records its target; ticks still far from it are dropped. Clears when a tick lands within 5s of the target, or after a 10s settle window (safety valve for a seek that genuinely ended elsewhere), and resets on episode/source switches.

### 5. Fast back-and-forth scrubbing wiped the episode's progress + selection — `bd59adf`

**Root cause (two pre-existing traps the held-press ramp reaches easily):** (a) a forward overshoot clamped the scrub target to the EXACT duration; committing that seeks into EOF, which is treated as "episode finished" → mark watched + auto-advance → progress wiped, selector moved. (b) A single tick past 90% marked the episode watched instantly, so a commit merely LANDING there flipped the marker even when the viewer scrubbed straight back.

**Fix:** the scrub clamp lands 5s before the end (full-range on ≤30s clips), so only natural playback reaches EOF and its finished semantics; and the 90% marker is dwell-gated (~5s of settled, non-scrubbing playback in the zone; leaving re-arms). Natural finishes unaffected — true EOF still marks watched via `endFileEof`.

### 6. Watched/unwatched toggle resurrected an ancient position — `70f20d9`

**Root cause:** progress has two writers — direct account-API saves and the engine's own library copy. The engine only heard the throttled tick + exit flush, and a scrub commit resets the throttle without telling it, so its copy could sit far behind; any engine-side push (the watched toggle, a sync) then carried that stale position with a fresh mtime and WON, resurrecting an old position over newer account writes.

**Fix:** report the position to the engine at the same boundaries the account gets — on pause and immediately on scrub commits (engine dispatches are ordered, so this can never race backward; deliberately NOT more network saves, which are unordered).

### 7. Reopening right after exit resumed at 0:00 and then clobbered the real position — `fe2efa6`

**Root cause:** `engineResumeSeconds` returns 0 not only for a fresh title but from its series-mismatch branch (stale `video_id` after a watched toggle / lagging sync), and the caller treated any non-nil engine answer as final — deliberately skipping the account lookup, out of a fear of wrong-episode resume that cannot happen: `account.resumeOffset` does its own `video_id` match. The bare 0 replayed from 0:00, and that session's early exit then saved ~0 over the real position.

**Fix:** take the engine's answer only when it's a real position (> 5s); otherwise consult the account, which is episode-safe by construction. Overlay profiles keep their private-history path inside `resumeOffset`, exactly as before.

### 8. Dashboard timestamp stale until a manual Details visit — `cf6530c`

**Root cause:** the player writes progress directly to the account API, which the engine cannot see until its next library sync — and nothing scheduled one after playback, so the Home Continue Watching card kept the pre-playback timestamp (and fed it into the next resume) until a detail-page load happened to trigger a sync.

**Fix:** the exit flush finishes the final account save and THEN dispatches `SyncLibraryWithAPI` (new `CoreBridge.syncLibraryNow()`), sequenced in the same task so the pull can't race the write. Exit-only; the periodic/pause saves don't each trigger an API sync.

**Verified on device:** CW timestamp corrects itself within a couple of seconds of exit, resume from the card is correct, no manual Details needed.

### 9. OPTIONAL — honest Streaming-cache presentation on tvOS — `f8cae48`

Not required by any fix above; drop this commit freely if unwanted. It removes the user-side trap that produced the original crash report: the tiers (2/5/10/20 GB / Unlimited) imply a big on-disk cache, but on this MPVKit build the buffer is held in MEMORY and every tier silently clamps to the same device-safe RAM ceiling (~768 MB on ATV 4K, from the existing `player.readAhead.*` RemoteConfig dial — the label reads it live, so a fleet re-tune re-labels itself). The reporter ran "2 GB" for weeks getting no cache beyond the ceiling, just ~3× the default memory exposure. tvOS presentation only: picker becomes Off / "On (up to N MB of memory)" (picking On stores the same 2 GB value as before — engine path, sync payloads, and iOS/iPadOS settings untouched), the footer says where the buffer lives and shows the actually-applied budget, and on the Apple TV HD the row is disabled with the reason (~128 MB ceiling barely exceeds the always-on buffer on 2 GB hardware). Trivially revertible if the on-disk offload ever starts working.

## Screenshots

Streaming cache setting (tvOS, Apple TV 4K), for the optional commit `f8cae48`:

**Before** (tiers implying a 2 GB disk cache; footer's "Cache budget: 2,15 GB" was never what the player applied):

<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/67992d6f-e70b-4651-99cb-561745231c0d" />


**After** (honest memory-capped binary + footer showing the real applied budget):

<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/47e54785-123e-4802-8261-56999d4602af" />


## Checks

- [x] Builds for tvOS (built + run on real Apple TV 4K hardware, VortXTVLite scheme, throughout the fix/test loop; `PlayerScreen.swift`/`AVPlayerEngine.swift` also touch iOS/Mac targets — those compile from the same shared sources but were not run on those platforms)
- [x] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`) — every new write path goes through the existing guards: `core.reportProgress` / `markPlaybackWatched` / `syncLibraryNow` guard engine-history internally, and `account.saveProgress` / `resumeOffset` route overlay profiles to `ProfileStore` as before
- [x] Screenshots attached for UI changes (the one visual change is the optional Streaming-cache row; before/after above)

## Notes / known follow-ups for the maintainer

- **iOS parity:** `PlayerScreen` shares the instant-90%-mark and scrub-stale-tick patterns (fixes 4–6 were applied tvOS-only because that's where they were device-verified); only the durationless-duration fallback (fix 2) was applied there. Happy to port the rest if wanted.
- **Two-writer progress architecture:** fixes 6–8 shrink the divergence windows between the direct account writes and the engine's synced copy to ~1–2s around exit, but the architecture (unordered network saves racing an mtime-last-write-wins sync) remains; a single-writer funnel would retire this bug class.
- **`cache-on-disk` never offloads** on this MPVKit build (the reason for commit 9 and part of fix 1's exposure); if that's ever fixed upstream, revert `f8cae48` and the big tiers become honest again.
- The paused-clamp values (60s grace, 48 MiB floor) and `cache-pause-wait=2` are conservative first picks, easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code) Fable 5 high setting

https://claude.ai/code/session_017TQQnj1cWjjAVWc6HbXKay

---
_Generated by [Claude Code](https://claude.ai/code/session_017TQQnj1cWjjAVWc6HbXKay)_