### PR TITLE
fix(android): resolve APK build failure (Kotlin/libmpv, ExoPlayer, CI artifact)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,9 +64,13 @@ jobs:
         working-directory: android
         run: gradle assembleDebug --no-daemon --stacktrace
 
+      # assembleDebug builds every flavor, and the full/play flavor split moved the outputs from
+      # apk/debug/ to apk/<flavor>/debug/ -- glob both so the artifact carries the sideload `full`
+      # APK and the `play` APK. error (not warn) so a path drift fails the job instead of silently
+      # uploading nothing.
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
           name: VortX-Android-debug
-          path: android/app/build/outputs/apk/debug/*.apk
-          if-no-files-found: warn
+          path: android/app/build/outputs/apk/*/debug/*.apk
+          if-no-files-found: error

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -53,12 +53,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/android/app/src/main/kotlin/com/stremiox/android/player/ExoPlayerEngine.kt
+++ b/android/app/src/main/kotlin/com/stremiox/android/player/ExoPlayerEngine.kt
@@ -124,7 +124,6 @@ class ExoPlayerEngine(context: Context) : PlayerEngine {
         } else {
             DefaultMediaSourceFactory(appContext)
         }
-        player.setMediaSourceFactory(mediaSourceFactory)
 
         // External sidecar subtitles as side-loaded text tracks on the MediaItem. ExoPlayer needs a
         // concrete, parseable subtitle MIME (unlike mpv, which sniffs the file), so infer it from the
@@ -143,7 +142,10 @@ class ExoPlayerEngine(context: Context) : PlayerEngine {
             .setSubtitleConfigurations(subtitleConfigs)
             .build()
 
-        player.setMediaItem(item)
+        // ExoPlayer has no runtime setMediaSourceFactory (that is a Builder-only API); the factory is
+        // applied per-load by creating the MediaSource here. DefaultMediaSourceFactory still handles the
+        // sidecar SubtitleConfigurations on the MediaItem (it merges them as side-loaded text tracks).
+        player.setMediaSource(mediaSourceFactory.createMediaSource(item))
         player.playWhenReady = true
         if (playable.startPositionMs > 0L) player.seekTo(playable.startPositionMs)
         player.prepare()

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,9 @@
 // Root build file. Plugin versions declared here, applied per-module. Kotlin 2.0+ is required for
-// the standalone Compose compiler plugin (org.jetbrains.kotlin.plugin.compose).
+// the standalone Compose compiler plugin (org.jetbrains.kotlin.plugin.compose); Kotlin 2.2+ is
+// required to read dev.jdtech.mpv:libmpv:1.0.0, whose .kotlin_module metadata is 2.2.0 (a 2.0.x
+// compiler can only read metadata up to 2.1 and fails :app:compileFullDebugKotlin on it).
 plugins {
     id("com.android.application") version "8.5.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
 }


### PR DESCRIPTION
## What and why

Fixes the Android APK build, which was failing on `:app:compileFullDebugKotlin` with a Kotlin internal compiler error (see [run 29169605713](https://github.com/jbecker-it/VortX/actions/runs/29169605713/job/86588498281)). Three issues, found and fixed in sequence as each one unblocked the next:

1. **Kotlin version mismatch** — `dev.jdtech.mpv:libmpv:1.0.0` ships `.kotlin_module` metadata built with Kotlin 2.2.0, which the project's Kotlin 2.0.20 compiler can't read (a compiler only reads metadata up to one minor version ahead). This crashed the compiler's own incompatible-class checker instead of producing a clean diagnostic. Bumped `org.jetbrains.kotlin.android` / `org.jetbrains.kotlin.plugin.compose` to 2.2.10 and migrated the deprecated `kotlinOptions` block to `compilerOptions`.
2. **Real compile error, previously masked** — once the compiler could get past the libmpv metadata, it surfaced `ExoPlayerEngine.kt:127: Unresolved reference 'setMediaSourceFactory'`. That method only exists on `ExoPlayer.Builder`, not at runtime on the built player. Fixed by building the `MediaSource` from the per-load header factory and passing it to `player.setMediaSource(...)` instead.
3. **Empty CI artifact** — the `full`/`play` product flavor split had moved `assembleDebug` output from `apk/debug/*.apk` to `apk/<flavor>/debug/*.apk`, so the upload step silently matched nothing and the workflow went green with an empty artifact. Updated the glob to `apk/*/debug/*.apk` and changed `if-no-files-found` from `warn` to `error` so this fails loudly if it happens again.

Verified with four `workflow_dispatch` runs on this branch, ending green with both `app-full-debug.apk` (138 MB, libmpv-primary sideload build) and `app-play-debug.apk` (32 MB, ExoPlayer-only) present in the uploaded artifact.

Android-only change; no Apple (tvOS/iOS/macOS) code touched.

## Screenshots

N/A — no UI changes.

## Checks

- [x] Android CI (`android.yml` / build-android) is green on this branch
- [x] If this touches watched state, progress, or resume: both profile paths handled (`activeUsesEngineHistory`, see CONTRIBUTING.md) — N/A, no state/resume changes
- [x] Screenshots attached for UI changes — N/A, no UI changes
