### PR TITLE
Add a Settings toggle to disable the Still watching prompt (#200)

### DIFF
--- a/app/Sources/PlayerScreen.swift
+++ b/app/Sources/PlayerScreen.swift
@@ -340,6 +340,9 @@ struct PlayerScreen: View {
     // pause playback and ask, so a binge does not run all night. ANY interaction re-arms it, so an
     // actively-attended session never trips. Mirrors TVPlayerView.
     @State private var stillWatchingPrompt = false          // the modal is up (playback paused, awaiting Continue / Stop)
+    // Settings toggle (#200): default ON = current behavior. Off disables BOTH triggers below; playback then
+    // runs uninterrupted (no idle pause, auto-advance proceeds without asking). SAME key TVPlayerView binds.
+    @AppStorage("vortx.stillWatchingPrompt") private var stillWatchingPromptEnabled = true
     @State private var idleDeadline = Date.distantFuture    // wall-clock idle deadline; pushed forward on every interaction
     @State private var idleWatchTask: Task<Void, Never>?    // single poll loop; started on open, cancelled on teardown
     @State private var consecutiveAutoAdvances = 0          // back-to-back auto-advances with no interaction between them
@@ -2031,7 +2034,7 @@ struct PlayerScreen: View {
                 // "Still watching?" binge guard: after N back-to-back auto-advances with zero interaction,
                 // pause at this boundary and ask instead of rolling straight on (Continue resumes the roll).
                 consecutiveAutoAdvances += 1
-                if consecutiveAutoAdvances >= Self.idleAutoAdvanceLimit {
+                if stillWatchingPromptEnabled, consecutiveAutoAdvances >= Self.idleAutoAdvanceLimit {
                     presentStillWatching(pendingNext: allEpisodeRefs[i + 1].id)
                 } else {
                     goToEpisode(allEpisodeRefs[i + 1].id, autoAdvance: true)
@@ -7679,6 +7682,7 @@ struct PlayerScreen: View {
     /// paused / buffering / panel / failed / scrubbing session (those are not "running all night", and a
     /// modal there is just noise); each is re-checked on the next poll tick.
     private func maybePromptStillWatching() {
+        guard stillWatchingPromptEnabled else { return }   // disabled: never interrupt an idle session
         guard hasStartedPlaying, !stillWatchingPrompt else { return }
         guard !isPaused, panel == nil, !scrubbing, !buffering, !loadFailed, !skipEditActive else { return }
         guard Date() >= idleDeadline else { return }

--- a/app/SourcesTV/SettingsView.swift
+++ b/app/SourcesTV/SettingsView.swift
@@ -117,6 +117,10 @@ struct SettingsView: View {
     // Auto-add watched to Library (D8): a title is added to the Library once ~60s of it has played.
     // Default ON. SAME key iOS/Mac binds; read at the 60s progress tick in the player.
     @AppStorage("stremiox.autoAddLibrary") private var autoAddLibrary = true
+    /// "Still watching?" prompt (#200): default ON = current behavior. Off disables both the idle-timeout
+    /// guard and the binge-boundary guard in TVPlayerView (and PlayerScreen, same key), so playback never
+    /// pauses to ask and auto-advance always proceeds straight through. SAME key iOS/Mac binds.
+    @AppStorage("vortx.stillWatchingPrompt") private var stillWatchingPromptEnabled = true
     // Default player volume 0-100 (D5): the level a new playback starts at. The in-player volume slider
     // writes this same key, so the last level persists; this picker sets it explicitly. SAME key as iOS/Mac.
     @AppStorage("stremiox.playerVolume") private var playerVolume = 100.0
@@ -574,6 +578,10 @@ struct SettingsView: View {
             choiceRow(String(localized: "Auto-add watched to Library"), [("0", "Off"), ("1", "On")],
                       selection: Binding(get: { autoAddLibrary ? "1" : "0" }, set: { autoAddLibrary = ($0 == "1") }))
             Text("Adds a title to your Library once about a minute of it has played, so it is easy to find again.")
+                .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
+            choiceRow(String(localized: "Still watching prompt"), [("0", "Off"), ("1", "On")],
+                      selection: Binding(get: { stillWatchingPromptEnabled ? "1" : "0" }, set: { stillWatchingPromptEnabled = ($0 == "1") }))
+            Text("Pauses and asks if you are still watching after a long idle stretch or many auto-played episodes. Turn off to keep playing.")
                 .font(Theme.Typography.label).foregroundStyle(Theme.Palette.textSecondary)
         }
     }
@@ -1558,7 +1566,7 @@ private enum SettingsSearchSection: CaseIterable {
                                 "player engine", "dolby vision", "mkv", "skip step", "auto-skip", "intro",
                                 "credits", "skip timestamps", "skip database", "seek bar", "community scrub previews",
                                 "trickplay", "autoplay trailers", "trailer language", "default volume",
-                                "auto-add watched", "play in", "external player"]
+                                "auto-add watched", "play in", "external player", "still watching", "idle"]
         case .downloads: return ["downloads", "auto-delete", "delete watched", "offline", "storage", "reclaim space"]
         case .notifications: return ["new episode alerts", "episode", "notification"]
         case .streams: return ["quality preset", "smart source selection", "add-on ranking", "source type",

--- a/app/SourcesTV/TVPlayerView.swift
+++ b/app/SourcesTV/TVPlayerView.swift
@@ -602,6 +602,9 @@ struct TVPlayerView: View {
     // or `idleAutoAdvanceLimit` back-to-back auto-advances with zero input) pause and ask, so a binge does
     // not run all night. ANY press / swipe re-arms it, so an attended session never trips. Mirrors PlayerScreen.
     @State private var stillWatching = false             // the modal is up (playback paused, awaiting Continue / Stop)
+    // Settings toggle (#200): default ON = current behavior. Off disables BOTH triggers below; playback then
+    // runs uninterrupted (no idle pause, auto-advance proceeds without asking). SAME key PlayerScreen binds.
+    @AppStorage("vortx.stillWatchingPrompt") private var stillWatchingPromptEnabled = true
     @State private var stillWatchingWantsStop = false    // remote focus: false = Continue (default), true = Stop
     @State private var idleDeadline: Date = .distantFuture   // wall-clock idle deadline; pushed forward on every press
     @State private var consecutiveAutoAdvances = 0        // back-to-back auto-advances with no interaction between them
@@ -6288,7 +6291,7 @@ struct TVPlayerView: View {
             // "Still watching?" binge guard: after N back-to-back auto-advances with zero remote input,
             // pause at this boundary and ask instead of rolling straight on (Continue resumes the roll).
             consecutiveAutoAdvances += 1
-            if consecutiveAutoAdvances >= Self.idleAutoAdvanceLimit {
+            if stillWatchingPromptEnabled, consecutiveAutoAdvances >= Self.idleAutoAdvanceLimit {
                 presentStillWatching(pendingAdvance: true)
             } else {
                 playNext()
@@ -8332,6 +8335,7 @@ struct TVPlayerView: View {
     /// Fire the timed prompt iff the session looks unattended AND is actually playing. Never interrupts a
     /// paused / buffering / options / failed session; each is re-checked on the next poll tick.
     private func maybePromptStillWatching() {
+        guard stillWatchingPromptEnabled else { return }   // disabled: never interrupt an idle session
         guard hasStartedPlaying, !stillWatching else { return }
         guard !isPaused, !showOptions, !buffering, !loadFailed else { return }
         guard Date() >= idleDeadline else { return }

--- a/app/SourcesiOS/iOSSettingsView.swift
+++ b/app/SourcesiOS/iOSSettingsView.swift
@@ -160,6 +160,10 @@ struct iOSSettingsView: View {
     /// Auto-add watched to Library (D8): when playback of a title crosses ~60s it is added to the Library.
     /// Default ON. Read at the 60s progress tick in PlayerScreen / TVPlayerView via LibraryAutoAdd.
     @AppStorage("stremiox.autoAddLibrary") private var autoAddLibrary = true
+    /// "Still watching?" prompt (#200): default ON = current behavior. Off disables both the idle-timeout
+    /// guard and the binge-boundary guard in PlayerScreen (and TVPlayerView, same key), so playback never
+    /// pauses to ask and auto-advance always proceeds straight through.
+    @AppStorage("vortx.stillWatchingPrompt") private var stillWatchingPromptEnabled = true
     /// Auto-delete watched downloads: when ON, a completed download whose title crosses the watched
     /// threshold is removed to reclaim space. Default OFF. Read by DownloadManager at its watched-state tick.
     @AppStorage(DownloadManager.autoDeleteWatchedDefaultsKey) private var autoDeleteWatched = false
@@ -736,6 +740,10 @@ struct iOSSettingsView: View {
             // account library). A manual removal is remembered so a title is not force-re-added on replay.
             Toggle("Auto-add watched to Library", isOn: $autoAddLibrary)
                 .tint(Theme.Palette.accent)
+            Toggle("Still watching prompt", isOn: $stillWatchingPromptEnabled)
+                .tint(Theme.Palette.accent)
+            Text("Pauses and asks if you are still watching after a long idle stretch or many auto-played episodes. Turn off to keep playing.")
+                .font(.caption).foregroundStyle(.secondary)
             #if os(iOS)
             Toggle("Landscape in player", isOn: $autoLandscapeInPlayer)
                 .tint(Theme.Palette.accent)
@@ -2055,7 +2063,7 @@ private enum SettingsSearchSection: CaseIterable {
                                 "credits", "skip timestamps", "skip database", "seek bar", "community scrub previews",
                                 "trickplay", "autoplay trailers", "trailer language", "default volume",
                                 "auto-add watched", "landscape", "background playback", "keep playing", "play in",
-                                "external player"]
+                                "external player", "still watching", "idle"]
         case .downloads: return ["downloads", "auto-delete", "delete watched", "offline", "storage", "reclaim space"]
         case .notifications: return ["new episode alerts", "episode", "notification"]
         case .streams: return ["quality preset", "smart source selection", "add-on ranking", "source type",


### PR DESCRIPTION
Implements #200: a synced **Still watching prompt** toggle in Playback settings on iOS, tvOS, and Mac.

- New `vortx.stillWatchingPrompt` preference (`@AppStorage`, default on, so existing behaviour is unchanged).
- When off, the Still watching modal never fires from either trigger (the 4-hour idle guard or the binge boundary after many auto-plays); playback and auto-advance continue uninterrupted.
- Syncs per profile like the other preference toggles (not in any SettingsBackup exclusion list).

Four files, one per surface: `PlayerScreen.swift` and `TVPlayerView.swift` (guards on both triggers), `iOSSettingsView.swift` and `SettingsView.swift` (the toggles).

Verified: VortXTVLite and VortXMac both compile clean.

Closes #200.